### PR TITLE
Switch sorting of rabbitmq comparaison and add variable to defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ collections/*
 !collections/requirements.yml
 galaxy.yml
 *.tar.gz
+
+# Ignore Vim working files
+.*.swp

--- a/roles/pre_tasks/defaults/main.yml
+++ b/roles/pre_tasks/defaults/main.yml
@@ -5,6 +5,9 @@
 #               Tower Installation Vars                    #
 ############################################################
 
+# Tower release version, either fixed e.g. 3.7.2 or "latest"
+tower_release_version: latest
+
 # Working location for installation files
 tower_working_location: "/var/tmp"
 

--- a/roles/pre_tasks/tasks/pre_tasks.yml
+++ b/roles/pre_tasks/tasks/pre_tasks.yml
@@ -8,7 +8,7 @@
 
 - name: "Determine whether RabbitMQ vars are required"
   set_fact:
-    rabbitmq_required: "{{ not ((tower_release_version is version(3.7, '>=')) or (tower_release_version == 'latest')) }}"
+    rabbitmq_required: "{{ not ((tower_release_version == 'latest') or (tower_release_version is version(3.7, '>='))) }}"
 
 # Download and Extract
 - name: "[Tower] Download and Extract Tower"


### PR DESCRIPTION
### What does this PR do?

Switch sorting of rabbitmq comparaison and add variable to defaults
    
the rabbitmq_required was comparing first with a version number then with 'latest', but 'latest'
can't be compared with a version, so it would fail before going to the 2nd step. Turning this
around solved the issue.
I also added the 'tower_release_version' variable to the defaults, where it was missing. 'latest' is the default, hope this is OK, for most demo/learning purposes, it's good enough I think.

And while I was at it, I've add Vim swap files to gitignore (bad habit I know).

### How should this be tested?

Install Tower with the 'latest' version resp. a fixed version and see that it doesn't fail any more.

### Is there a relevant Issue open for this?

n/a

### Other Relevant info, PRs, etc.

n/a