### PR TITLE
Isolated nodes install

### DIFF
--- a/roles/install/README.md
+++ b/roles/install/README.md
@@ -44,7 +44,11 @@ tower_ssh_connection_vars: ''
 isolated_groups:
   - name: dmz1
     hostnames:
-    - isolatednode.example.com
+    - isolatednode0.dmz1example.com
+  - name: dmz2
+    hostnames:
+    - isolatednode0.dmz2.example.com
+    - isolatednode1.dmz2.example.com
 
 ```
 

--- a/roles/install/README.md
+++ b/roles/install/README.md
@@ -39,6 +39,13 @@ tower_database: ""
 tower_database_port: ""
 
 tower_ssh_connection_vars: ''
+
+# Set isolated groups for isolated nodes if required
+isolated_groups:
+  - name: dmz1
+    hostnames:
+    - isolatednode.example.com
+
 ```
 
 ## tower_ssh_connection_vars

--- a/roles/install/README.md
+++ b/roles/install/README.md
@@ -44,7 +44,7 @@ tower_ssh_connection_vars: ''
 isolated_groups:
   - name: dmz1
     hostnames:
-    - isolatednode0.dmz1example.com
+    - isolatednode0.dmz1.example.com
   - name: dmz2
     hostnames:
     - isolatednode0.dmz2.example.com

--- a/roles/pre_tasks/templates/inventory.j2
+++ b/roles/pre_tasks/templates/inventory.j2
@@ -33,3 +33,62 @@ rabbitmq_vhost="{{ tower_rabbitmq_vhost }}"
 rabbitmq_use_long_name="{{ tower_rabbitmq_use_long_name }}"
 
 {% endif %}
+
+[tower]
+{% for item in tower_hosts %}
+{{ item }}
+{% endfor %}
+
+[database]
+{{ tower_database }}
+
+[all:vars]
+admin_password='{{ tower_admin_password }}'
+
+{% if tower_ssh_connection_vars is defined %}
+{% for item in tower_ssh_connection_vars %}
+{{ item.name}}='{{ item.value }}'
+{% endfor %}
+{% endif %}
+
+# Define Remote PostgreSQL for Tower
+pg_host='{{ tower_database }}'
+pg_port='{{ tower_database_port }}'
+
+pg_database='{{ tower_pg_database }}'
+pg_username='{{ tower_pg_username }}'
+pg_password='{{ tower_pg_password }}'
+
+{% if rabbitmq_required %}
+
+rabbitmq_username='{{ tower_rabbitmq_username }}'
+rabbitmq_password='{{ tower_rabbitmq_password }}'
+rabbitmq_cookie='{{ tower_rabbitmq_cookie }}'
+rabbitmq_port="{{ tower_rabbitmq_port }}"
+rabbitmq_vhost="{{ tower_rabbitmq_vhost }}"
+rabbitmq_use_long_name="{{ tower_rabbitmq_use_long_name }}"
+
+{% endif %}
+
+
+{% if isolated_groups is defined %}
+
+{% for item in isolated_groups %}
+[isolated_group_{{ item.name }}]
+{% for host in item.hostnames %}
+{{ host }}
+{% endfor %}
+{% endfor %}
+
+{% for item in isolated_groups %}
+[isolated_group_{{ item.name }}:vars]
+controller=tower
+{% endfor %}
+
+{% endif %}
+
+
+
+
+
+

--- a/roles/pre_tasks/templates/inventory.j2
+++ b/roles/pre_tasks/templates/inventory.j2
@@ -34,42 +34,6 @@ rabbitmq_use_long_name="{{ tower_rabbitmq_use_long_name }}"
 
 {% endif %}
 
-[tower]
-{% for item in tower_hosts %}
-{{ item }}
-{% endfor %}
-
-[database]
-{{ tower_database }}
-
-[all:vars]
-admin_password='{{ tower_admin_password }}'
-
-{% if tower_ssh_connection_vars is defined %}
-{% for item in tower_ssh_connection_vars %}
-{{ item.name}}='{{ item.value }}'
-{% endfor %}
-{% endif %}
-
-# Define Remote PostgreSQL for Tower
-pg_host='{{ tower_database }}'
-pg_port='{{ tower_database_port }}'
-
-pg_database='{{ tower_pg_database }}'
-pg_username='{{ tower_pg_username }}'
-pg_password='{{ tower_pg_password }}'
-
-{% if rabbitmq_required %}
-
-rabbitmq_username='{{ tower_rabbitmq_username }}'
-rabbitmq_password='{{ tower_rabbitmq_password }}'
-rabbitmq_cookie='{{ tower_rabbitmq_cookie }}'
-rabbitmq_port="{{ tower_rabbitmq_port }}"
-rabbitmq_vhost="{{ tower_rabbitmq_vhost }}"
-rabbitmq_use_long_name="{{ tower_rabbitmq_use_long_name }}"
-
-{% endif %}
-
 {% if isolated_groups is defined %}
 
 {% for item in isolated_groups %}

--- a/roles/pre_tasks/templates/inventory.j2
+++ b/roles/pre_tasks/templates/inventory.j2
@@ -70,7 +70,6 @@ rabbitmq_use_long_name="{{ tower_rabbitmq_use_long_name }}"
 
 {% endif %}
 
-
 {% if isolated_groups is defined %}
 
 {% for item in isolated_groups %}
@@ -86,9 +85,3 @@ controller=tower
 {% endfor %}
 
 {% endif %}
-
-
-
-
-
-


### PR DESCRIPTION
### What does this PR do?
Adds compatibility for the automated configuring of isolated node groups

### How should this be tested?
I have tested this manually. The first test was adding one isolated group with one isolated nodes. The second test was two isolated groups, each with a single node underneath them. Both tests passed. Attached are screen shots of the playbook completing (inventory populating correctly and tower installing), as well as Ansible Tower with the new instance groups.

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
This PR is based off the manual process of adding isolated nodes to an inventory file. More information here: https://developers.redhat.com/blog/2017/12/20/understanding-ansible-tower-isolated-nodes/ 

![image](https://user-images.githubusercontent.com/43852257/97734498-28354980-1ad1-11eb-84d2-450e1e836bac.png)

![image](https://user-images.githubusercontent.com/43852257/97734602-4ac76280-1ad1-11eb-8bef-13ce59c48c9b.png)
