### PR TITLE
Add the tower_virtual_environments role from tower_configuration

### DIFF
--- a/roles/tower_virtual_environments/README.md
+++ b/roles/tower_virtual_environments/README.md
@@ -1,0 +1,54 @@
+# tower_configuration.tower_virtual_environments
+
+## Description
+An Ansible Role to manage Python virtual environments in Ansible Tower.
+
+## Variables
+|Variable Name|Default Value|Required|Description|Type|
+|---|:---:|:---:|---|:---:|
+|tower_venv_pylibs | ["ansible-tower-cli"] | yes | List of Python libraries to install from pip.  This should be a list of Python libraries that certain Ansible modules require to run. If just the package name is provided (i.e. without [package-name]-[version] **example:** *`ansible-tower-cli-3.3.2`*) the latest version will be installed (**example:** *`ansible-tower-cli`* will get latest version available). | list |
+| tower_venv_path | "/var/lib/awx/venv/ansible" | no | Path to the Ansible Tower virtual environment you would like to operate on. If the path does not exist, the directory, along with the required Ansible Tower base depencenies (`python-memcached psutil`).| string |
+| tower_venv_umask | "0022" | no | System umask to apply before installing the pip package. | string |
+
+## Playbook Examples
+### Standard Role Usage
+```yaml
+---
+- hosts: "all"
+  roles:
+    - role: "tower_virtual_environments"
+      tower_venv_pylibs:
+        - "ansible-tower-cli"
+        - "boto"
+```
+### Imported Role
+```yaml
+---
+- hosts: "all"
+  vars:
+    tower_venv_pylibs:
+      - "ansible-tower-cli"
+      - "boto"
+  tasks:
+    - name: "Ensure Ansible Prerequisites are installed"
+      import_role:
+        name: "tower_virtual_environments"
+```
+### Included Role
+```yaml
+---
+- hosts: "all"
+  tasks:
+    - name: "Ensure Ansible Prerequisites are installed"
+      include_role:
+        name: "tower_virtual_environments"
+      vars:
+        tower_venv_pylibs:
+          - "ansible-tower-cli"
+          - "boto"
+```
+## License
+[MIT](LICENSE)
+
+## Author
+[Andrew J. Huffman](https://github.com/ahuffman)

--- a/roles/tower_virtual_environments/defaults/main.yml
+++ b/roles/tower_virtual_environments/defaults/main.yml
@@ -1,0 +1,23 @@
+---
+tower_venv_pylibs:
+  - "ansible-tower-cli"
+tower_venv_umask: "0022"
+tower_venv_path: "/var/lib/awx/venv/ansible"
+requirements: "true"
+pip_req: "false"
+virtual_offline: "false"
+virtual_online: "true"
+virtual_backup: "false"
+virtualenv_rpms:
+  - gcc
+  - python-pip
+  - krb5-devel
+  - python-gssapi
+
+tower_venv_installs:
+  - name: rhv-cloud
+    package_path: pip-deps
+    reqts_file: pip-reqts-provisioner.txt
+  - name: networking
+    package_path: pip-deps
+    reqts_file: pip-reqts-provisioner.txt

--- a/roles/tower_virtual_environments/meta/main.yml
+++ b/roles/tower_virtual_environments/meta/main.yml
@@ -1,0 +1,59 @@
+---
+galaxy_info:
+  role_name: "tower_virtual_environments"
+  author: "Andrew J. Huffman"
+  description: "An Ansible Role to manage virtual environments in Ansible Tower."
+  company: "Red Hat"
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Some suggested licenses:
+  # - BSD (default)
+  # - MIT
+  # - GPLv2
+  # - GPLv3
+  # - Apache
+  # - CC-BY
+  license: "MIT"
+
+  min_ansible_version: "2.4"
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  # Optionally specify the branch Galaxy will use when accessing the GitHub
+  # repo for this role. During role install, if no tags are available,
+  # Galaxy will use this branch. During import Galaxy will access files on
+  # this branch. If Travis integration is configured, only notifications for this
+  # branch will be accepted. Otherwise, in all cases, the repo's default branch
+  # (usually master) will be used.
+  # github_branch:
+
+  #
+  # platforms is a list of platforms, and each platform has a name and a list of versions.
+  #
+  platforms:
+    - name: "EL"
+      versions:
+        - "all"
+
+  galaxy_tags:
+    - "ansibletower"
+    - "tower"
+    - "awx"
+    - "configuration"
+    - "virtualenvironment"
+    - "python"
+    - "environment"
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.

--- a/roles/tower_virtual_environments/molecule/default/INSTALL.rst
+++ b/roles/tower_virtual_environments/molecule/default/INSTALL.rst
@@ -1,0 +1,22 @@
+*******
+Docker driver installation guide
+*******
+
+Requirements
+============
+
+* Docker Engine
+
+Install
+=======
+
+Please refer to the `Virtual environment`_ documentation for installation best
+practices. If not using a virtual environment, please consider passing the
+widely recommended `'--user' flag`_ when invoking ``pip``.
+
+.. _Virtual environment: https://virtualenv.pypa.io/en/latest/
+.. _'--user' flag: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
+
+.. code-block:: bash
+
+    $ pip install 'molecule[docker]'

--- a/roles/tower_virtual_environments/molecule/default/converge.yml
+++ b/roles/tower_virtual_environments/molecule/default/converge.yml
@@ -1,0 +1,7 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+    - name: "Include tower_virtual_environments"
+      include_role:
+        name: "tower_virtual_environments"

--- a/roles/tower_virtual_environments/molecule/default/molecule.yml
+++ b/roles/tower_virtual_environments/molecule/default/molecule.yml
@@ -1,0 +1,13 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: instance
+    image: docker.io/pycontribs/centos:7
+    pre_build_image: true
+provisioner:
+  name: ansible
+verifier:
+  name: ansible

--- a/roles/tower_virtual_environments/molecule/default/verify.yml
+++ b/roles/tower_virtual_environments/molecule/default/verify.yml
@@ -1,0 +1,9 @@
+---
+# This is an example playbook to execute Ansible tests.
+
+- name: Verify
+  hosts: all
+  tasks:
+  - name: Example assertion
+    assert:
+      that: true

--- a/roles/tower_virtual_environments/tasks/backup.yml
+++ b/roles/tower_virtual_environments/tasks/backup.yml
@@ -1,0 +1,17 @@
+---
+
+- name: Create a directory for custom virtual environments
+  file:
+    path: "{{ tower_venv_tmp }}/venv/"
+    group: root
+    mode: 0755
+    owner: root
+    state: directory
+
+- name: compress the virtual environments
+  archive:
+    path: "{{ tower_venv_path }}"
+    dest: "{{ tower_venv_tmp }}/{{ backup_date }}"
+    format: gz
+    mode: 0755
+    owner: root

--- a/roles/tower_virtual_environments/tasks/init_venv.yml
+++ b/roles/tower_virtual_environments/tasks/init_venv.yml
@@ -1,0 +1,18 @@
+---
+- name: "Ensure virtual environment path exists"
+  file:
+    mode: "0755"
+    owner: "awx"
+    group: "awx"
+    path: "{{ tower_venv_path }}"
+    state: directory
+  become: true
+
+- name: "Ensure virtual environment has Ansible Tower base dependencies"
+  pip:
+    name: "{{ tower_venv_base_deps }}"
+    umask: "{{ tower_venv_umask }}"
+    virtualenv: "{{ tower_venv_path }}"
+    virtualenv_command: "virtualenv"
+    state: present
+  become: true

--- a/roles/tower_virtual_environments/tasks/main.yml
+++ b/roles/tower_virtual_environments/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+- name: Find the current run time.
+  set_fact:
+    backup_date: '{{ lookup("pipe", "date +%F-%T") }}'
+
+- name: Include Requirements
+  include_tasks: requirements.yml
+  when: requirements|bool
+
+- name: Include Online Virtualenv
+  include_tasks: online.yml
+  when: virtual_online|bool
+
+- name: Include Offline Virtualenv
+  include_tasks: offline.yml
+  when: virtual_offline|bool
+
+- name: Include Backup of the Virtualenv
+  include_tasks: online.yml
+  when: virtual_backup|bool

--- a/roles/tower_virtual_environments/tasks/offline.yml
+++ b/roles/tower_virtual_environments/tasks/offline.yml
@@ -1,0 +1,31 @@
+---
+
+- name: "Ensure virtual environment path exists"
+  file:
+    mode: "0755"
+    owner: "awx"
+    group: "awx"
+    path: "{{ tower_venv_path }}"
+    state: "directory"
+  become: true
+  when: create_venv_path == 'true'
+
+
+- name: Copy Over the Python Libraries For Offline Install
+  copy:
+    src: "{{ item.package_path }}"
+    dest: "{{ tower_tmp_path }}"
+    mode: "preserve"  # not required, but E208 in lint without it
+  loop: "{{ tower_venv_installs }}"
+
+- name: Install the Python Libraries in a created virtualenv Offline
+  pip:
+    virtualenv_site_packages: true
+    requirements: "{{ tower_tmp_path }}/{{ item.package_path }}/{{ item.reqts_file }}"
+    umask: "{{ tower_venv_umask }}"
+    virtualenv: "{{ tower_venv_path }}/{{ item.name }}"
+    virtualenv_command: "virtualenv"
+    extra_args: "--no-index --find-links file://{{ tower_tmp_path }}/{{ item.package_path }}"
+    state: "present"
+  become: true
+  loop: "{{ tower_venv_installs }}"

--- a/roles/tower_virtual_environments/tasks/online.yml
+++ b/roles/tower_virtual_environments/tasks/online.yml
@@ -1,0 +1,23 @@
+---
+
+
+- name: "Check virtual environment exists"
+  stat:
+    get_attributes: false
+    get_checksum: false
+    get_mime: false
+    path: "{{ tower_venv_path }}"
+  register: "tower_venv_path_check"
+
+- name: "Initialize virtual environment"
+  include_tasks: "init_venv.yml"
+  when: 'not tower_venv_path_check.stat.exists'
+
+- name: "Ensure Python libraries are installed to virtual environment"
+  pip:
+    name: "{{ tower_venv_pylibs }}"
+    umask: "{{ tower_venv_umask }}"
+    virtualenv: "{{ tower_venv_path }}"
+    virtualenv_command: "virtualenv"
+    state: "present"
+  become: true

--- a/roles/tower_virtual_environments/tasks/requirements.yml
+++ b/roles/tower_virtual_environments/tasks/requirements.yml
@@ -1,0 +1,6 @@
+---
+
+- name: Required Pip packages For Virtualenv
+  yum:
+    name: "{{ virtualenv_rpms }}"
+    state: installed

--- a/roles/tower_virtual_environments/vars/main.yml
+++ b/roles/tower_virtual_environments/vars/main.yml
@@ -1,0 +1,4 @@
+---
+tower_venv_base_deps:
+  - "python-memcached"
+  - "psutil"


### PR DESCRIPTION
### What does this PR do?

Add the tower_virtual_environments removed from tower_configuration collection through https://github.com/redhat-cop/tower_configuration/pull/122 as it fits better in the collection, being close to the operating system and not using the awx.awx collection.

### How should this be tested?

n/a I didn't change the functionality.

### Is there a relevant Issue open for this?

relates to https://github.com/redhat-cop/tower_configuration/issues/118

### Other Relevant info, PRs, etc.

https://github.com/redhat-cop/tower_configuration/pull/122

(the PR for Kerberos follows but it creates a conflict)