### PR TITLE
Force Install Option

### DIFF
--- a/roles/install/README.md
+++ b/roles/install/README.md
@@ -12,6 +12,7 @@ Available variables are listed below, along with default values defined (see def
 
 ```yaml
 tower_working_location: "/root/"
+tower_force_setup: true
 
 # Tower variables
 tower_admin_password: "password"

--- a/roles/install/defaults/main.yml
+++ b/roles/install/defaults/main.yml
@@ -7,3 +7,4 @@
 
 tower_url: "https://localhost"
 tower_server: "{{ tower_url }}"
+tower_force_setup: true

--- a/roles/install/tasks/tower_install.yml
+++ b/roles/install/tasks/tower_install.yml
@@ -10,6 +10,7 @@
   register: tower_install_check
   ignore_errors: true
   failed_when: false
+  when: tower_force_setup == false
 
 - block:
     # Run the Setup
@@ -32,5 +33,5 @@
       retries: 90
       delay: 10
   when:
-    - tower_install_check.status != 200
+    - tower_force_setup == true or tower_install_check.status != 200
 ...

--- a/roles/install/tasks/tower_install.yml
+++ b/roles/install/tasks/tower_install.yml
@@ -10,7 +10,7 @@
   register: tower_install_check
   ignore_errors: true
   failed_when: false
-  when: tower_force_setup == false
+  when: not tower_force_setup
 
 - block:
     # Run the Setup
@@ -33,5 +33,5 @@
       retries: 90
       delay: 10
   when:
-    - tower_force_setup == true or tower_install_check.status != 200
+    - tower_force_setup or tower_install_check.status != 200
 ...


### PR DESCRIPTION
### What does this PR do?
Adds option for forcing installer to run.

### How should this be tested?
set var tower_force_install=false and run role twice. The installer should not run the 2nd time.

### Is there a relevant Issue open for this?
previous PR removed this capability resulting in the role being unusable for upgrades. 

### Other Relevant info, PRs, etc.
Please provide link to other PRs that may be related (blocking, resolves, etc. etc.)
https://github.com/redhat-cop/tower_utilities/pull/25