### PR TITLE
Introduce basic installation of Automation Hub

### DIFF
--- a/roles/backup/README.md
+++ b/roles/backup/README.md
@@ -35,7 +35,7 @@ tower_setup_file: ansible-tower-setup-{{ tower_release_version }}.tar.gz
 tower_hosts:
   - "localhost ansible_connection=local"
 
-tower_database: ""
+tower_database_host: ""
 tower_database_port: ""
 
 tower_ssh_connection_vars: ''

--- a/roles/backup/README.md
+++ b/roles/backup/README.md
@@ -75,7 +75,7 @@ $ ansible-playbook playbook.yml -e @tower_vars.yml tower
   vars:
     tower_hosts:
       - "clusternode[1:3].example.com"
-    tower_database: "dbnode.example.com"
+    tower_database_host: "dbnode.example.com"
     tower_working_location: "{{playbook_dir}}"
   roles:
     - redhat_cop.tower_utilities.backup

--- a/roles/install/README.md
+++ b/roles/install/README.md
@@ -101,7 +101,7 @@ $ ansible-playbook playbook.yml -e @tower_vars.yml tower
   vars:
     tower_hosts:
       - "clusternode[1:3].example.com"
-    tower_database: "dbnode.example.com"
+    tower_database_host: "dbnode.example.com"
     tower_database_port: "5432"
   roles:
     - redhat_cop.tower_utilities.install

--- a/roles/install/README.md
+++ b/roles/install/README.md
@@ -36,7 +36,7 @@ tower_setup_file: ansible-tower-setup-{{ tower_release_version }}.tar.gz
 tower_hosts:
   - "localhost ansible_connection=local"
 
-tower_database: ""
+tower_database_host: ""
 tower_database_port: ""
 
 tower_ssh_connection_vars: ''

--- a/roles/pre_tasks/README.md
+++ b/roles/pre_tasks/README.md
@@ -38,7 +38,7 @@ tower_setup_file: ansible-tower-setup-{{ tower_release_version }}.tar.gz
 tower_hosts:
   - "localhost ansible_connection=local"
 
-tower_database: ""
+tower_database_host: ""
 tower_database_port: ""
 
 tower_ssh_connection_vars: ''
@@ -92,7 +92,7 @@ $ ansible-playbook playbook.yml -e @tower_vars.yml tower
   vars:
     tower_hosts:
       - "clusternode[1:3].example.com"
-    tower_database: "dbnode.example.com"
+    tower_database_host: "dbnode.example.com"
     tower_database_port: "5432"
   roles:
     - redhat_cop.tower_utilities.install

--- a/roles/pre_tasks/README.md
+++ b/roles/pre_tasks/README.md
@@ -42,7 +42,25 @@ tower_database_host: ""
 tower_database_port: ""
 
 tower_ssh_connection_vars: ''
+
+# as long as the host name is empty, Automation Hub will NOT be installed
+tower_ah_hosts: []
+
+# the default configures an AH using the default database with similar defaults
+# as Tower
+tower_ah_admin_password: "{{ tower_admin_password }}"
+# if tower_database_host isn't defined or is empty,
+# the host where the installation takes place is deemed to host the DB
+tower_ah_pg_host: "{{ tower_database_host | default(ansible_host | default(inventory_hostname), true) }}"
+tower_ah_pg_port: "{{ tower_database_port }}"
+tower_ah_pg_database: 'automationhub'  # it is NOT supported to use the same name as for Tower!
+tower_ah_pg_username: "{{ tower_pg_username }}"
+tower_ah_pg_password: "{{ tower_pg_password }}"
+tower_ah_pg_sslmode: prefer
 ```
+
+> **CAUTION:** even if it is a list, it hasn't been tested that the installation of more than one AH is possible,
+	especially as it would surely require a mean to have multiple database names.
 
 ## tower_ssh_connection_vars
 

--- a/roles/pre_tasks/defaults/main.yml
+++ b/roles/pre_tasks/defaults/main.yml
@@ -61,7 +61,7 @@ tower_ah_admin_password: "{{ tower_admin_password }}"
 # the host where the installation takes place is deemed to host the DB
 tower_ah_pg_host: "{{ tower_database_host | default(ansible_host | default(inventory_hostname), true) }}"
 tower_ah_pg_port: "{{ tower_database_port }}"
-tower_ah_pg_database: 'automationhub'
+tower_ah_pg_database: 'automationhub'  # it is NOT supported to use the same name as for Tower!
 tower_ah_pg_username: "{{ tower_pg_username }}"
 tower_ah_pg_password: "{{ tower_pg_password }}"
 tower_ah_pg_sslmode: prefer

--- a/roles/pre_tasks/defaults/main.yml
+++ b/roles/pre_tasks/defaults/main.yml
@@ -15,7 +15,7 @@ tower_working_location: "/var/tmp"
 tower_admin_password: "password"
 
 # Use the default tower installation template
-pre_tasks_process_template: True
+pre_tasks_process_template: true
 
 # Postgresql variables
 tower_pg_database: "awx"
@@ -43,5 +43,53 @@ tower_server: "https://localhost"
 tower_hosts:
   - "localhost ansible_connection=local"
 
-tower_database: ""
+tower_database_host: ""
 tower_database_port: "5432"
+
+############################################################
+# Automation Hub (AH) Configuration
+############################################################
+
+# as long as the host name is empty, Automation Hub will NOT be installed
+# FIXME: not sure if more than one automation hub is really possible
+tower_ah_hosts: []
+
+# the default configures an AH using the default database with similar defaults
+# as Tower
+tower_ah_admin_password: "{{ tower_admin_password }}"
+# if tower_database_host isn't defined or is empty,
+# the host where the installation takes place is deemed to host the DB
+tower_ah_pg_host: "{{ tower_database_host | default(ansible_host | default(inventory_hostname), true) }}"
+tower_ah_pg_port: "{{ tower_database_port }}"
+tower_ah_pg_database: 'automationhub'
+tower_ah_pg_username: "{{ tower_pg_username }}"
+tower_ah_pg_password: "{{ tower_pg_password }}"
+tower_ah_pg_sslmode: prefer
+
+# TODO add SSL handling variables to automation
+# The default install will deploy a TLS enabled Automation Hub.
+# If for some reason this is not the behavior wanted one can
+# disable TLS enabled deployment.
+#
+# tower_ah_disable_https: False
+# The default install will generate self-signed certificates for the Automation
+# Hub service. If you are providing valid certificate via automationhub_ssl_cert
+# and automationhub_ssl_key, one should toggle that value to True.
+#
+# tower_ah_ssl_validate_certs: False
+# Isolated Tower nodes automatically generate an RSA key for authentication;
+# To disable this behavior, set this value to false
+# isolated_key_generation=true
+# SSL-related variables
+# If set, this will install a custom CA certificate to the system trust store.
+# custom_ca_cert=/path/to/ca.crt
+# Certificate and key to install in nginx for the web UI and API
+# web_server_ssl_cert=/path/to/tower.cert
+# web_server_ssl_key=/path/to/tower.key
+# Certificate and key to install in Automation Hub node
+# tower_ah_ssl_cert: /path/to/automationhub.cert
+# tower_ah_ssl_key: /path/to/automationhub.key
+# Server-side SSL settings for PostgreSQL (when we are installing it).
+# postgres_use_ssl=False
+# postgres_ssl_cert=/path/to/pgsql.crt
+# postgres_ssl_key=/path/to/pgsql.key

--- a/roles/pre_tasks/meta/main.yml
+++ b/roles/pre_tasks/meta/main.yml
@@ -13,6 +13,7 @@ galaxy_info:
     - name: EL
       versions:
         - 7
+        - 8
 
   galaxy_tags:
     - linux

--- a/roles/pre_tasks/tasks/main.yml
+++ b/roles/pre_tasks/tasks/main.yml
@@ -49,3 +49,16 @@
     src: inventory.j2
     dest: "{{ tower_setup_dir }}/inventory"
   when: pre_tasks_process_template
+
+# FIXME when installing Tower standalone with the embedded database (i.e. without adding a host to the [database] group) and configuring AH to use the same DB, it fails because the firewall isn't opened for PostgreSQL by the installation playbooks. Not sure yet if it's something we should fix in this role, like:
+# - name: Enable Standalone Database firewall ports
+#   firewalld:
+#     port: '{{ tower_database_port }}/tcp'
+#     permanent: true
+#     state: enabled
+#     immediate: yes
+#     zone: "{{ tower_firewalld_zone }}"
+#   when:
+#   - not tower_database_host|bool
+#   - tower_database_port == tower_ah_pg_port  # if the ports are different, something is at least fishy
+#   - tower_ah_pg_host == ansible_host or tower_ah_pg_host == inventory_hostname

--- a/roles/pre_tasks/templates/inventory.j2
+++ b/roles/pre_tasks/templates/inventory.j2
@@ -3,8 +3,17 @@
 {{ item }}
 {% endfor %}
 
+{% if tower_database_host %}
 [database]
-{{ tower_database }}
+{{ tower_database_host }}
+{% endif %}
+
+{% if tower_ah_hosts %}
+[automationhub]
+{% for ah_host in tower_ah_hosts %}
+{{ ah_host }}
+{% endfor %}
+{% endif %}
 
 [all:vars]
 admin_password='{{ tower_admin_password }}'
@@ -16,7 +25,7 @@ admin_password='{{ tower_admin_password }}'
 {% endif %}
 
 # Define Remote PostgreSQL for Tower
-pg_host='{{ tower_database }}'
+pg_host='{{ tower_database_host }}'
 pg_port='{{ tower_database_port }}'
 
 pg_database='{{ tower_pg_database }}'
@@ -32,6 +41,43 @@ rabbitmq_port="{{ tower_rabbitmq_port }}"
 rabbitmq_vhost="{{ tower_rabbitmq_vhost }}"
 rabbitmq_use_long_name="{{ tower_rabbitmq_use_long_name }}"
 
+{% endif %}
+
+{% if tower_ah_hosts %}
+automationhub_admin_password='{{ tower_ah_admin_password }}'
+automationhub_pg_host='{{ tower_ah_pg_host }}'
+automationhub_pg_port='{{ tower_ah_pg_port }}'
+automationhub_pg_database='{{ tower_ah_pg_database }}'
+automationhub_pg_username='{{ tower_ah_pg_database }}'
+automationhub_pg_password='{{ tower_ah_pg_database }}'
+automationhub_pg_sslmode='{{ tower_ah_pg_sslmode }}'
+# TODO add SSL handling variables to automation
+# The default install will deploy a TLS enabled Automation Hub.
+# If for some reason this is not the behavior wanted one can
+# disable TLS enabled deployment.
+#
+# automationhub_disable_https = False
+# The default install will generate self-signed certificates for the Automation
+# Hub service. If you are providing valid certificate via automationhub_ssl_cert
+# and automationhub_ssl_key, one should toggle that value to True.
+#
+# automationhub_ssl_validate_certs = False
+# Isolated Tower nodes automatically generate an RSA key for authentication;
+# To disable this behavior, set this value to false
+# isolated_key_generation=true
+# SSL-related variables
+# If set, this will install a custom CA certificate to the system trust store.
+# custom_ca_cert=/path/to/ca.crt
+# Certificate and key to install in nginx for the web UI and API
+# web_server_ssl_cert=/path/to/tower.cert
+# web_server_ssl_key=/path/to/tower.key
+# Certificate and key to install in Automation Hub node
+# automationhub_ssl_cert=/path/to/automationhub.cert
+# automationhub_ssl_key=/path/to/automationhub.key
+# Server-side SSL settings for PostgreSQL (when we are installing it).
+# postgres_use_ssl=False
+# postgres_ssl_cert=/path/to/pgsql.crt
+# postgres_ssl_key=/path/to/pgsql.key
 {% endif %}
 
 {% if isolated_groups is defined %}

--- a/roles/restore/README.md
+++ b/roles/restore/README.md
@@ -38,7 +38,7 @@ tower_setup_file: ansible-tower-setup-{{ tower_release_version }}.tar.gz
 tower_hosts:
   - "localhost ansible_connection=local"
 
-tower_database: ""
+tower_database_host: ""
 tower_database_port: ""
 ```
 
@@ -60,7 +60,7 @@ $ ansible-playbook playbook.yml -e @tower_vars.yml tower
   vars:
     tower_hosts:
       - "clusternode[1:3].example.com"
-    tower_database: "dbnode.example.com"
+    tower_database_host: "dbnode.example.com"
     tower_working_location: "{{playbook_dir}}"
     restore_location: "{{playbook_dir}}/tower-backup-latest.tar.gz"
   roles:

--- a/roles/tower_cert/README.md
+++ b/roles/tower_cert/README.md
@@ -47,7 +47,7 @@ $ ansible-playbook playbook.yml -e @tower_vars.yml tower
   vars:
     tower_hosts:
       - "clusternode[1:3].example.com"
-    tower_database: "dbnode.example.com"
+    tower_database_host: "dbnode.example.com"
     tower_database_port: "5432"
   roles:
     - ansible-tower-install


### PR DESCRIPTION
### What does this PR do?
the basic configuration works, using the database deployed by the Tower installer, and self-signed certificates;
a more complex configuration with standalone/external database should be possible, but not tested. I didn't even look at the SSL configuration aspects.
I took also the chance to rename 'tower_database' to 'tower_database_host' which is clearer.

### How should this be tested?

Add the `tower_ah_...` variables to your inventory and re-run the setup.

### Is there a relevant Issue open for this?
n/a

### Other Relevant info, PRs, etc.

The installation fails when installing a single node Tower with embedded database, and with the AH using the embedded database, because the setup playbooks don't open the firewall. I only added a commented out potential fix, subject to discussion (because @sean-m-sullivan said he needs the role to work without admin rights).
