### PR TITLE
update docs

### DIFF
--- a/roles/backup/README.md
+++ b/roles/backup/README.md
@@ -55,6 +55,8 @@ tower_ssh_connection_vars:
     value: vagrant
   - name: ansible_ssh_private_key_file
     value: /path/to/file
+  - name: ansible_become
+    value: true
 ```
 
 ## Example Playbook

--- a/roles/install/README.md
+++ b/roles/install/README.md
@@ -55,7 +55,7 @@ isolated_groups:
 
 ## tower_ssh_connection_vars
 
-Connection vars can be set in the inventory file through a list of vars. Please note, at minimum ansible_become should be set to true here as the Tower installation requires root access.
+Connection vars can be set in the inventory file through a list of vars.
 
 ```yaml
 tower_ssh_connection_vars:

--- a/roles/install/README.md
+++ b/roles/install/README.md
@@ -55,7 +55,7 @@ isolated_groups:
 
 ## tower_ssh_connection_vars
 
-connection vars can be set in the inventory file through a list of vars
+Connection vars can be set in the inventory file through a list of vars. Please note, at minimum ansible_become should be set to true here as the Tower installation requires root access.
 
 ```yaml
 tower_ssh_connection_vars:
@@ -67,6 +67,8 @@ tower_ssh_connection_vars:
     value: vagrant
   - name: ansible_ssh_private_key_file
     value: /path/to/file
+  - name: ansible_become
+    value: true
 ```
 
 ## Example Playbook

--- a/roles/install/tasks/tower_install.yml
+++ b/roles/install/tasks/tower_install.yml
@@ -15,7 +15,6 @@
 - block:
     # Run the Setup
     - name: "[Tower] Run the Ansible Tower Setup Program"
-      become: true
       command: ./setup.sh
       args:
         chdir: "{{ tower_setup_dir }}"

--- a/roles/pre_tasks/README.md
+++ b/roles/pre_tasks/README.md
@@ -76,6 +76,8 @@ tower_ssh_connection_vars:
     value: vagrant
   - name: ansible_ssh_private_key_file
     value: /path/to/file
+  - name: ansible_become
+    value: true
 ```
 
 ## Example Playbook


### PR DESCRIPTION
### What does this PR do?
Removes the need for root access on the "control node/bastion" from which the playbook is run. (Recent customer has this issue). This fix will only run as root on the targeted machine not on the local machine. Most customers have root logins disabled.

### How should this be tested?
This has been manually tested. to test just run the install as normal, remembering to specify ssh_connection_vars as described in the README"

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A
