### PR TITLE
fix inventory.j2 for AH

### DIFF
--- a/roles/pre_tasks/templates/inventory.j2
+++ b/roles/pre_tasks/templates/inventory.j2
@@ -48,8 +48,8 @@ automationhub_admin_password='{{ tower_ah_admin_password }}'
 automationhub_pg_host='{{ tower_ah_pg_host }}'
 automationhub_pg_port='{{ tower_ah_pg_port }}'
 automationhub_pg_database='{{ tower_ah_pg_database }}'
-automationhub_pg_username='{{ tower_ah_pg_database }}'
-automationhub_pg_password='{{ tower_ah_pg_database }}'
+automationhub_pg_username='{{ tower_ah_pg_username }}'
+automationhub_pg_password='{{ tower_ah_pg_password }}'
 automationhub_pg_sslmode='{{ tower_ah_pg_sslmode }}'
 # TODO add SSL handling variables to automation
 # The default install will deploy a TLS enabled Automation Hub.


### PR DESCRIPTION
### What does this PR do?
Update to reflect the changes suggested in the issue.

automationhub_pg_database='{{ tower_ah_pg_database }}'
automationhub_pg_username='{{ tower_ah_pg_database }}'
automationhub_pg_password='{{ tower_ah_pg_database }}'

Should be:

automationhub_pg_database='{{ tower_ah_pg_database }}'
automationhub_pg_username='{{ tower_ah_pg_username }}'
automationhub_pg_password='{{ tower_ah_pg_password }}'

### How should this be tested?
Tested manually, deploys AH successfully with this change

### Is there a relevant Issue open for this?
https://github.com/redhat-cop/tower_utilities/issues/37

### Other Relevant info, PRs, etc.

