### PR TITLE
Change tower_certs vars

### DIFF
--- a/roles/tower_cert/README.md
+++ b/roles/tower_cert/README.md
@@ -1,6 +1,6 @@
-# ansible-tower-cert
+# redhat_cop.tower_utilities.tower_cert
 
-Ansible role to install Ansible Tower Certificate.
+Ansible role to install a new Ansible Tower Certificate. Note it is also possible to use the `install` role to deploy a certificate at install time using `tower_ssl_cert` and `tower_ssl_key`
 
 ## Requirements
 
@@ -11,8 +11,8 @@ None
 Available variables are listed below, along with default values defined (see defaults/main.yml)
 
 ```yaml
-tower_cert_location: "{{ playbook_dir }}/tower.cert"
-tower_cert_key_location: "{{ playbook_dir }}/tower.key"
+tower_ssl_cert: "{{ playbook_dir }}/tower.cert"
+tower_ssl_key: "{{ playbook_dir }}/tower.key"
 ```
 
 ## Example Playbook
@@ -27,28 +27,12 @@ $ ansible-playbook playbook.yml -e @tower_vars.yml tower
 ---
 # Playbook to install Ansible Tower as a single node
 
-- name: Install Ansible Tower
+- name: Install Ansible Tower Certificate
   hosts: tower
   become: true
   vars:
-    tower_tower_releases_url: https://releases.ansible.com/ansible-tower/setup-bundle
-    tower_tower_release_version: bundle-3.6.3-1.tar.gz
-  roles:
-    - ansible-tower-install
-```
-
-```yaml
----
-# Playbook to install Ansible Tower as a cluster
-
-- name: Setup Ansible Tower
-  hosts: localhost
-  become: true
-  vars:
-    tower_hosts:
-      - "clusternode[1:3].example.com"
-    tower_database_host: "dbnode.example.com"
-    tower_database_port: "5432"
+    tower_ssl_cert: /var/tmp/tower.cert
+    tower_ssl_key: /var/tmp/tower.key
   roles:
     - ansible-tower-install
 ```

--- a/roles/tower_cert/defaults/main.yml
+++ b/roles/tower_cert/defaults/main.yml
@@ -1,4 +1,8 @@
 ---
+# Deprecated variables kept for backwards compatability
 tower_cert_location: "{{ playbook_dir }}/tower.cert"
 tower_cert_key_location: "{{ playbook_dir }}/tower.key"
+
+tower_ssl_cert: "{{ tower_cert_location }}"
+tower_ssl_key: "{{ tower_cert_key_location }}"
 ...

--- a/roles/tower_cert/meta/main.yml
+++ b/roles/tower_cert/meta/main.yml
@@ -1,6 +1,6 @@
 ---
 galaxy_info:
-  role_name: ansible-tower-cert
+  role_name: redhat_cop.tower_utilities.tower_certs
   author: Tom Page
   description: Role to install Ansible Tower Certificates
   company: Red Hat

--- a/roles/tower_cert/tasks/main.yml
+++ b/roles/tower_cert/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Copy cert into place
   become: true
   copy:
-    src: "{{ tower_cert_location }}"
+    src: "{{ tower_ssl_cert }}"
     dest: /etc/tower/tower.cert
   notify:
     - Restart Ansible tower service
@@ -10,7 +10,7 @@
 - name: Copy cert key into place
   become: true
   copy:
-    src: "{{ tower_cert_key_location }}"
+    src: "{{ tower_ssl_key }}"
     dest: /etc/tower/tower.key
   notify:
     - Restart Ansible tower service


### PR DESCRIPTION
### What does this PR do?
Changes the variable used for tower_certs role to match the variable used in the install role. This way it would be easier for a customer to maintain the variable and be able to apply just the cert role if they needed to update the certs.

I have ensured backwards compatibility by just defaulting the new vars to be the value of the old vars. That way this will not be a breaking change

### How should this be tested?
N/A just a var name change.

### Is there a relevant Issue open for this?
No

### Other Relevant info, PRs, etc.
N/A
