### PR TITLE
Allow deployment of only AH

### DIFF
--- a/roles/install/README.md
+++ b/roles/install/README.md
@@ -1,6 +1,8 @@
 # redhat_cop.tower_utilities.install
 
-Ansible role to prep to install Ansible Tower and Ansible automation hub.
+Ansible role to prep to install Ansible Tower and Ansible Automation Hub.
+
+The role utilises the Ansible Automation Platform installer. For more information see [the Ansible Automation Platform Installation Guide](https://docs.ansible.com/ansible-tower/latest/html/installandreference/index.html).
 
 ## Requirements
 

--- a/roles/install/tasks/tower_install.yml
+++ b/roles/install/tasks/tower_install.yml
@@ -10,11 +10,24 @@
   register: tower_install_check
   ignore_errors: true
   failed_when: false
-  when: not tower_force_setup
+  when: tower_hosts != [] and not tower_force_setup
+
+- name: Check Automation Hub Running
+  uri:
+    url: "{{ tower_ah_url }}/api/galaxy/"
+    method: GET
+    user: admin
+    password: "{{ tower_admin_password }}"
+    validate_certs: false
+    force_basic_auth: true
+  register: tower_ah_install_check
+  ignore_errors: true
+  failed_when: false
+  when: tower_ah_hosts != [] and not tower_force_setup
 
 - block:
     # Run the Setup
-    - name: "[Tower] Run the Ansible Tower Setup Program"
+    - name: "[Tower] Run the Ansible Automation Platform Setup Program"
       command: ./setup.sh
       args:
         chdir: "{{ tower_setup_dir }}"
@@ -22,7 +35,7 @@
       poll: 20
       changed_when: false   # these will always run and will always report “changed” otherwise
 
-    - name: Wait for ansible tower to be running.
+    - name: Wait for Ansible Tower to be running.
       uri:
         url: "{{ tower_url }}"
         status_code: 200
@@ -31,6 +44,18 @@
       until: result.status == 200
       retries: 90
       delay: 10
+      when: tower_hosts != []
+
+    - name: Wait for Automation Hub to be running.
+      uri:
+        url: "{{ tower_ah_url }}/ui/"
+        status_code: 200
+        validate_certs: false
+      register: result_ah
+      until: result_ah.status == 200
+      retries: 90
+      delay: 10
+      when: tower_ah_hosts != []
   when:
-    - tower_force_setup or tower_install_check.status != 200
+    - tower_force_setup or (tower_hosts != [] and tower_install_check.status != 200) or (tower_ah_hosts != [] and tower_ah_install_check.status != 200)
 ...


### PR DESCRIPTION
### What does this PR do?
Changes to check for Automation Hub to be running and only check tower when tower_hosts specified. Also adds more description to the README and a link to the AAP install docs.

### How should this be tested?
Try to deploy only AH (set `tower_hosts: []`) and see that we don't try to query the tower api any more.

### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.
resolves #31

### Other Relevant info, PRs, etc.
N/A
