### PR TITLE
Ah def

### DIFF
--- a/roles/install/defaults/main.yml
+++ b/roles/install/defaults/main.yml
@@ -6,6 +6,7 @@
 ############################################################
 
 tower_url: "https://localhost"
+tower_ah_url: "https://localhost"
 tower_server: "{{ tower_url }}"
 tower_force_setup: true
 ...


### PR DESCRIPTION
### What does this PR do?
Adds a sensible default to `tower_ah_url`

### How should this be tested?
Run through deploying a ah only deployment without `tower_ah_url` will break previously. Now will not.

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A