### PR TITLE
Add a check mode option to go a bit further in check mode

### DIFF
--- a/roles/pre_tasks/tasks/main.yml
+++ b/roles/pre_tasks/tasks/main.yml
@@ -7,6 +7,7 @@
   register: __towerutils_type_packages
   ignore_errors: yes
   changed_when: false
+  check_mode: false  # run this command even in check mode
 
 - name: "Install absolutely necessary packages"
   yum:


### PR DESCRIPTION
### What does this PR do?
Just adding a `check_mode: false` to the RPM check to make the check mode go a little bit further without error (it helps making sure nothing is fully wrong).

### How should this be tested?
Just call a playbook where you install Tower in check mode and see that it fails a bit later than without the patch...

### Is there a relevant Issue open for this?
n/a

### Other Relevant info, PRs, etc.
n/a
