### PR TITLE
Rename all cluster variables from hosts to nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ collections:
 
 ## Release and Upgrade Notes
 
+- After v0.4.0 the variable `tower_hosts` was renamed to `tower_nodes` in order to not collide with the variable of the same name in the redhat\_cop.tower\_configuration collection.
+Similarly, the variables tower\_ah\_nodes, tower\_database\_node and tower\_ah\_pg\_node were introduced/renamed.
+Don't forget to adapt your inventory/ies and variable definitions accordingly.
+
 ## Roadmap
 
 ## Contributing to this collection

--- a/roles/backup/README.md
+++ b/roles/backup/README.md
@@ -36,23 +36,23 @@ tower_rabbitmq_use_long_name: false
 tower_releases_url: https://releases.ansible.com/ansible-tower/setup
 tower_setup_file: ansible-tower-setup-{{ tower_release_version }}.tar.gz
 
-tower_hosts:
+tower_nodes:
   - "localhost ansible_connection=local"
 
-tower_database_host: ""
+tower_database_node: ""
 tower_database_port: ""
 
 tower_ssh_connection_vars: ''
 
 # as long as the host name is empty, Automation Hub will NOT be installed
-tower_ah_hosts: []
+tower_ah_nodes: []
 
 # the default configures an AH using the default database with similar defaults
 # as Tower
 tower_ah_admin_password: "{{ tower_admin_password }}"
-# if tower_database_host isn't defined or is empty,
+# if tower_database_node isn't defined or is empty,
 # the host where the installation takes place is deemed to host the DB
-tower_ah_pg_host: "{{ tower_database_host | default(ansible_host | default(inventory_hostname), true) }}"
+tower_ah_pg_node: "{{ tower_database_node | default(ansible_host | default(inventory_hostname), true) }}"
 tower_ah_pg_port: "{{ tower_database_port }}"
 tower_ah_pg_database: 'automationhub'  # it is NOT supported to use the same name as for Tower!
 tower_ah_pg_username: "{{ tower_pg_username }}"
@@ -113,9 +113,9 @@ $ ansible-playbook playbook.yml -e @tower_vars.yml tower
   hosts: localhost
   become: true
   vars:
-    tower_hosts:
+    tower_nodes:
       - "clusternode[1:3].example.com"
-    tower_database_host: "dbnode.example.com"
+    tower_database_node: "dbnode.example.com"
     tower_working_location: "{{playbook_dir}}"
   roles:
     - redhat_cop.tower_utilities.backup

--- a/roles/install/README.md
+++ b/roles/install/README.md
@@ -41,23 +41,23 @@ tower_rabbitmq_use_long_name: false
 tower_releases_url: https://releases.ansible.com/ansible-tower/setup
 tower_setup_file: ansible-tower-setup-{{ tower_release_version }}.tar.gz
 
-tower_hosts:
+tower_nodes:
   - "localhost ansible_connection=local"
 
-tower_database_host: ""
+tower_database_node: ""
 tower_database_port: ""
 
 tower_ssh_connection_vars: ''
 
 # as long as the host name is empty, Automation Hub will NOT be installed
-tower_ah_hosts: []
+tower_ah_nodes: []
 
 # the default configures an AH using the default database with similar defaults
 # as Tower
 tower_ah_admin_password: "{{ tower_admin_password }}"
-# if tower_database_host isn't defined or is empty,
+# if tower_database_node isn't defined or is empty,
 # the host where the installation takes place is deemed to host the DB
-tower_ah_pg_host: "{{ tower_database_host | default(ansible_host | default(inventory_hostname), true) }}"
+tower_ah_pg_node: "{{ tower_database_node | default(ansible_host | default(inventory_hostname), true) }}"
 tower_ah_pg_port: "{{ tower_database_port }}"
 tower_ah_pg_database: 'automationhub'  # it is NOT supported to use the same name as for Tower!
 tower_ah_pg_username: "{{ tower_pg_username }}"
@@ -134,8 +134,8 @@ $ ansible-playbook playbook.yml -e @tower_vars.yml tower
   hosts: tower
   become: true
   vars:
-    tower_hosts: []
-    tower_ah_hosts:
+    tower_nodes: []
+    tower_ah_nodes:
       - "localhost ansible_connection=local"
   roles:
     - redhat_cop.tower_utilities.install
@@ -149,9 +149,9 @@ $ ansible-playbook playbook.yml -e @tower_vars.yml tower
   hosts: localhost
   become: true
   vars:
-    tower_hosts:
+    tower_nodes:
       - "clusternode[1:3].example.com"
-    tower_database_host: "dbnode.example.com"
+    tower_database_node: "dbnode.example.com"
     tower_database_port: "5432"
   roles:
     - redhat_cop.tower_utilities.install

--- a/roles/install/tasks/tower_install.yml
+++ b/roles/install/tasks/tower_install.yml
@@ -10,7 +10,7 @@
   register: tower_install_check
   ignore_errors: true
   failed_when: false
-  when: tower_hosts != [] and not tower_force_setup
+  when: tower_nodes != [] and not tower_force_setup
 
 - name: Check Automation Hub Running
   uri:
@@ -23,7 +23,7 @@
   register: tower_ah_install_check
   ignore_errors: true
   failed_when: false
-  when: tower_ah_hosts != [] and not tower_force_setup
+  when: tower_ah_nodes != [] and not tower_force_setup
 
 - block:
     # Run the Setup
@@ -44,7 +44,7 @@
       until: result.status == 200
       retries: 90
       delay: 10
-      when: tower_hosts != []
+      when: tower_nodes != []
 
     - name: Wait for Automation Hub to be running.
       uri:
@@ -55,7 +55,7 @@
       until: result_ah.status == 200
       retries: 90
       delay: 10
-      when: tower_ah_hosts != []
+      when: tower_ah_nodes != []
   when:
-    - tower_force_setup or (tower_hosts != [] and tower_install_check.status != 200) or (tower_ah_hosts != [] and tower_ah_install_check.status != 200)
+    - tower_force_setup or (tower_nodes != [] and tower_install_check.status != 200) or (tower_ah_nodes != [] and tower_ah_install_check.status != 200)
 ...

--- a/roles/pre_tasks/README.md
+++ b/roles/pre_tasks/README.md
@@ -35,23 +35,23 @@ tower_rabbitmq_use_long_name: false
 tower_releases_url: https://releases.ansible.com/ansible-tower/setup
 tower_setup_file: ansible-tower-setup-{{ tower_release_version }}.tar.gz
 
-tower_hosts:
+tower_nodes:
   - "localhost ansible_connection=local"
 
-tower_database_host: ""
+tower_database_node: ""
 tower_database_port: ""
 
 tower_ssh_connection_vars: ''
 
 # as long as the host name is empty, Automation Hub will NOT be installed
-tower_ah_hosts: []
+tower_ah_nodes: []
 
 # the default configures an AH using the default database with similar defaults
 # as Tower
 tower_ah_admin_password: "{{ tower_admin_password }}"
-# if tower_database_host isn't defined or is empty,
+# if tower_database_node isn't defined or is empty,
 # the host where the installation takes place is deemed to host the DB
-tower_ah_pg_host: "{{ tower_database_host | default(ansible_host | default(inventory_hostname), true) }}"
+tower_ah_pg_node: "{{ tower_database_node | default(ansible_host | default(inventory_hostname), true) }}"
 tower_ah_pg_port: "{{ tower_database_port }}"
 tower_ah_pg_database: 'automationhub'  # it is NOT supported to use the same name as for Tower!
 tower_ah_pg_username: "{{ tower_pg_username }}"
@@ -129,8 +129,8 @@ $ ansible-playbook playbook.yml -e @tower_vars.yml tower
   hosts: tower
   become: true
   vars:
-    tower_hosts: []
-    tower_ah_hosts:
+    tower_nodes: []
+    tower_ah_nodes:
       - "localhost ansible_connection=local"
   roles:
     - redhat_cop.tower_utilities.install
@@ -144,9 +144,9 @@ $ ansible-playbook playbook.yml -e @tower_vars.yml tower
   hosts: localhost
   become: true
   vars:
-    tower_hosts:
+    tower_nodes:
       - "clusternode[1:3].example.com"
-    tower_database_host: "dbnode.example.com"
+    tower_database_node: "dbnode.example.com"
     tower_database_port: "5432"
   roles:
     - redhat_cop.tower_utilities.install

--- a/roles/pre_tasks/defaults/main.yml
+++ b/roles/pre_tasks/defaults/main.yml
@@ -40,10 +40,10 @@ tower_server: "https://localhost"
 ############################################################
 
 # Default setup for a single node instance with internal DB
-tower_hosts:
+tower_nodes:
   - "localhost ansible_connection=local"
 
-tower_database_host: ""
+tower_database_node: ""
 tower_database_port: "5432"
 
 ############################################################
@@ -52,14 +52,14 @@ tower_database_port: "5432"
 
 # as long as the host name is empty, Automation Hub will NOT be installed
 # FIXME: not sure if more than one automation hub is really possible
-tower_ah_hosts: []
+tower_ah_nodes: []
 
 # the default configures an AH using the default database with similar defaults
 # as Tower
 tower_ah_admin_password: "{{ tower_admin_password }}"
-# if tower_database_host isn't defined or is empty,
+# if tower_database_node isn't defined or is empty,
 # the host where the installation takes place is deemed to host the DB
-tower_ah_pg_host: "{{ tower_database_host | default(ansible_host | default(inventory_hostname), true) }}"
+tower_ah_pg_node: "{{ tower_database_node | default(ansible_host | default(inventory_hostname), true) }}"
 tower_ah_pg_port: "{{ tower_database_port }}"
 tower_ah_pg_database: 'automationhub'  # it is NOT supported to use the same name as for Tower!
 tower_ah_pg_username: "{{ tower_pg_username }}"
@@ -78,8 +78,8 @@ tower_ah_pg_sslmode: prefer
 # tower_ssl_key: ~/certs/{{ tower_server | urlsplit('hostname') }}.key
 
 # Server-side SSL settings for PostgreSQL (when we are installing it).
-# tower_pg_ssl_cert: ~/certs/{{ tower_database_host }}.crt
-# tower_pg_ssl_key: ~/certs/{{ tower_database_host }}.key
+# tower_pg_ssl_cert: ~/certs/{{ tower_database_node }}.crt
+# tower_pg_ssl_key: ~/certs/{{ tower_database_node }}.key
 
 # If set, this will install a custom CA certificate to the system trust store.
 # tower_custom_ca_cert: /etc/ipa/ca.crt

--- a/roles/pre_tasks/tasks/main.yml
+++ b/roles/pre_tasks/tasks/main.yml
@@ -59,7 +59,7 @@
 #     immediate: yes
 #     zone: "{{ tower_firewalld_zone }}"
 #   when:
-#   - not tower_database_host|bool
+#   - not tower_database_node|bool
 #   - tower_database_port == tower_ah_pg_port  # if the ports are different, something is at least fishy
-#   - tower_ah_pg_host == ansible_host or tower_ah_pg_host == inventory_hostname
+#   - tower_ah_pg_node == ansible_host or tower_ah_pg_node == inventory_hostname
 ...

--- a/roles/pre_tasks/templates/inventory.j2
+++ b/roles/pre_tasks/templates/inventory.j2
@@ -1,16 +1,16 @@
 [tower]
-{% for item in tower_hosts %}
+{% for item in tower_nodes %}
 {{ item }}
 {% endfor %}
 
-{% if tower_database_host %}
+{% if tower_database_node %}
 [database]
-{{ tower_database_host }}
+{{ tower_database_node }}
 {% endif %}
 
-{% if tower_ah_hosts %}
+{% if tower_ah_nodes %}
 [automationhub]
-{% for ah_host in tower_ah_hosts %}
+{% for ah_host in tower_ah_nodes %}
 {{ ah_host }}
 {% endfor %}
 {% endif %}
@@ -25,7 +25,7 @@ admin_password='{{ tower_admin_password }}'
 {% endif %}
 
 # Define Remote PostgreSQL for Tower
-pg_host='{{ tower_database_host }}'
+pg_host='{{ tower_database_node }}'
 pg_port='{{ tower_database_port }}'
 
 pg_database='{{ tower_pg_database }}'
@@ -43,9 +43,9 @@ rabbitmq_use_long_name="{{ tower_rabbitmq_use_long_name }}"
 
 {% endif %}
 
-{% if tower_ah_hosts %}
+{% if tower_ah_nodes %}
 automationhub_admin_password='{{ tower_ah_admin_password }}'
-automationhub_pg_host='{{ tower_ah_pg_host }}'
+automationhub_pg_host='{{ tower_ah_pg_node }}'
 automationhub_pg_port='{{ tower_ah_pg_port }}'
 automationhub_pg_database='{{ tower_ah_pg_database }}'
 automationhub_pg_username='{{ tower_ah_pg_username }}'

--- a/roles/restore/README.md
+++ b/roles/restore/README.md
@@ -38,23 +38,23 @@ tower_rabbitmq_use_long_name: false
 tower_releases_url: https://releases.ansible.com/ansible-tower/setup
 tower_setup_file: ansible-tower-setup-{{ tower_release_version }}.tar.gz
 
-tower_hosts:
+tower_nodes:
   - "localhost ansible_connection=local"
 
-tower_database_host: ""
+tower_database_node: ""
 tower_database_port: ""
 
 tower_ssh_connection_vars: ''
 
 # as long as the host name is empty, Automation Hub will NOT be installed
-tower_ah_hosts: []
+tower_ah_nodes: []
 
 # the default configures an AH using the default database with similar defaults
 # as Tower
 tower_ah_admin_password: "{{ tower_admin_password }}"
-# if tower_database_host isn't defined or is empty,
+# if tower_database_node isn't defined or is empty,
 # the host where the installation takes place is deemed to host the DB
-tower_ah_pg_host: "{{ tower_database_host | default(ansible_host | default(inventory_hostname), true) }}"
+tower_ah_pg_node: "{{ tower_database_node | default(ansible_host | default(inventory_hostname), true) }}"
 tower_ah_pg_port: "{{ tower_database_port }}"
 tower_ah_pg_database: 'automationhub'  # it is NOT supported to use the same name as for Tower!
 tower_ah_pg_username: "{{ tower_pg_username }}"
@@ -97,9 +97,9 @@ $ ansible-playbook playbook.yml -e @tower_vars.yml tower
   hosts: localhost
   become: true
   vars:
-    tower_hosts:
+    tower_nodes:
       - "clusternode[1:3].example.com"
-    tower_database_host: "dbnode.example.com"
+    tower_database_node: "dbnode.example.com"
     tower_working_location: "{{playbook_dir}}"
     restore_location: "{{playbook_dir}}/tower-backup-latest.tar.gz"
   roles:


### PR DESCRIPTION
### What does this PR do?
It appears that tower_hosts clashes with tower_collection/roles/hosts' variable of same name;
and the other nodes (AH and database) for being consistent.

### How should this be tested?
Inventory variables must be renamed and provisioning tried.

### Is there a relevant Issue open for this?
see Google Chat...

### Other Relevant info, PRs, etc.
n/a
