### PR TITLE
fixing default tower_ah_url

### DIFF
--- a/roles/install/defaults/main.yml
+++ b/roles/install/defaults/main.yml
@@ -6,7 +6,7 @@
 ############################################################
 
 tower_url: "https://localhost"
-tower_ah_url: "https://localhost"
+tower_ah_url: "https://{{ tower_ah_nodes[0] | default('localhost') }}"
 tower_server: "{{ tower_url }}"
 tower_force_setup: true
 ...


### PR DESCRIPTION
### What does this PR do?
fix an issue where tower_ah_url would default to localhost and not the ah_node[0] as expected

### How should this be tested?
Automated

### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.
resolves #51 

### Other Relevant info, PRs, etc.
none
