### PR TITLE
Add aap_setup_install role

### DIFF
--- a/roles/aap_setup_install/README.md
+++ b/roles/aap_setup_install/README.md
@@ -1,0 +1,38 @@
+Role Name
+=========
+
+A brief description of the role goes here.
+
+Requirements
+------------
+
+Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+
+Role Variables
+--------------
+
+A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+
+Dependencies
+------------
+
+A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+
+Example Playbook
+----------------
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+    - hosts: servers
+      roles:
+         - { role: username.rolename, x: 42 }
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+An optional section for the role authors to include contact information, or a website (HTML is not allowed).

--- a/roles/aap_setup_install/README.md
+++ b/roles/aap_setup_install/README.md
@@ -1,31 +1,53 @@
-Role Name
-=========
+aap\_setup\_install
+=================
 
-A brief description of the role goes here.
+A role to install AAP 2.x, installing pre-requisites, unpacking the installation tarball and (optionally) writing the necessary inventory file.
 
 Requirements
 ------------
 
-Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+* The installation package must have been extracted
+* The necessary inventory must have been written
 
 Role Variables
 --------------
 
-A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+The following input variables are available:
+
+|Variable Name|Default Value|Required|Description|Example|
+|---:|:---:|:---:|:---|:---:|
+|`aap_setup_inst_setup_dir`|"`{{ aap_setup_prep_setup_dir }}`"|no|absolute path where to find the extracted installation tarball on the remote host, note that `aap_setup_prep_setup_dir` is a fact set by the role `aap_setup_prepare`|'/var/tmp/myinstaller'|
+|`aap_setup_inst_inventory`|"`inventory`"|no|path to the inventory file/directory to be used for the installation, the path can be absolute or relative to the previous directory|'/etc/ansible/inventory'|
+|`aap_setup_inst_extra_vars`|`{}`|no|dictionary of extra vars to use when calling setup.sh|see [defaults/main.yml](defaults/main.yml)|
+|`controller_hostname/username/password/validate_certs`|none|see below|hostname and credentials of the installed controller, necessary to test previous installation|see the 'redhat\_cop.controller\_configuration' collection|
+|`ah_hostname/username/password/validate_certs`|none|see below|hostname and credentials of the installed automation hub, necessary to test previous installation|see the 'redhat\_cop.ah\_configuration' collection|
+|`aap_setup_inst_force`|false|no|a boolean deciding if the installation should proceed even if the controller and the automation hub are already installed|see [defaults/main.yml](defaults/main.yml)|
+
+Note that the `controller_` and `ah_` variables are only required if the variable `aap_setup_inst_force` is _not_ true _and_ if the respective service is due to be installed.
 
 Dependencies
 ------------
 
-A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+* `aap_setup_download`, in the same collection, can be used to download the tarball automatically.
+* `aap_setup_prepare`, in the same collection, can be used to extract the tarball and write the inventory
 
 Example Playbook
 ----------------
 
-Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+```yaml
+- name: download and install AAP from the bastion
+  hosts: bastion
+  gather_facts: false
+  become: false
+  tags: aap_installation
+  roles:
+    - redhat_cop.tower_utilities.aap_setup_download
+    - redhat_cop.tower_utilities.aap_setup_prepare
+    - redhat_cop.tower_utilities.aap_setup_install
+```
 
-    - hosts: servers
-      roles:
-         - { role: username.rolename, x: 42 }
+Note that this only works without root access if the bastion host isn't part of the future cluster, and if the RPM pre-requisites have been pre-installed.
+Else change to `become: true`.
 
 License
 -------
@@ -35,4 +57,4 @@ BSD
 Author Information
 ------------------
 
-An optional section for the role authors to include contact information, or a website (HTML is not allowed).
+Eric Lavarde <elavarde@redhat.com>

--- a/roles/aap_setup_install/defaults/main.yml
+++ b/roles/aap_setup_install/defaults/main.yml
@@ -7,6 +7,7 @@ aap_setup_inst_setup_dir: "{{ aap_setup_prep_setup_dir }}"
 # where is the inventory file, relative to the above directory _or_ absolute:
 aap_setup_inst_inventory: inventory
 
+# dictionary of extra vars used when calling setup.sh
 aap_setup_inst_extra_vars: {}
 #  # When installing automation controller make sure Ansible is also up to date
 #  upgrade_ansible_with_tower: false
@@ -47,6 +48,7 @@ aap_setup_inst_extra_vars: {}
 # These are the default variables common to most ah_configuration
 # and controller_utilities roles
 # You shouldn't need to define them again and again but they should be defined
+#
 # ah_hostname: "{{ inventory_hostname }}"
 # ah_username: "admin"
 # ah_password: ""

--- a/roles/aap_setup_install/defaults/main.yml
+++ b/roles/aap_setup_install/defaults/main.yml
@@ -1,0 +1,57 @@
+---
+# defaults file for aap_setup_install
+
+# where is the setup directory
+aap_setup_inst_setup_dir: "{{ aap_setup_prep_setup_dir }}"
+
+# where is the inventory file, relative to the above directory _or_ absolute:
+aap_setup_inst_inventory: inventory
+
+aap_setup_inst_extra_vars: {}
+#  # When installing automation controller make sure Ansible is also up to date
+#  upgrade_ansible_with_tower: false
+#  # When installing Tower also create the Demo Org, project, credential, Job Template, etc.
+#  create_preload_data: true
+#  # When installing from a bundle where to put the bundled repos
+#  bundle_install_folder: var/lib/tower-bundle
+#  # Disable HTTPS traffic through nginx, this is useful if offloading HTTPS to a load balancer
+#  nginx_disable_https: false
+#  # Disable HSTS web-security policy mechanism
+#  nginx_disable_hsts: false
+#  # Port to configure nginx to listen to for HTTP
+#  nginx_http_port: 80
+#  # Port to configure nginx to listen to for HTTPS
+#  nginx_https_port: 443
+#  # A temp location to use when backing up
+#  backup_dir: /var/backups/tower/
+#  # Specify an alternative backup file to restore from
+#  restore_backup_file: None
+#  # The minimum RAM required to install Tower (should only be changed for test installation)
+#  required_ram: 3750
+#  # The minimum open file descriptions (should only be changed for test installations)
+#  min_open_fds: None
+#  # Ignore preflight checks, useful when installing into a template or other non-system image (overrides required_ram and min_open_fds)
+#  ignore_preflight_errors: false
+
+# These are the default variables common to most controller_configuration
+# and _utilities roles
+# You shouldn't need to define them again and again but they should be defined
+#
+# controller_hostname: "{{ inventory_hostname }}"
+# controller_username: "admin"
+# controller_password: ""
+# controller_oauthtoken: ""
+# controller_config_file: ""
+# controller_validate_certs: false
+
+# These are the default variables common to most ah_configuration
+# and controller_utilities roles
+# You shouldn't need to define them again and again but they should be defined
+# ah_hostname: "{{ inventory_hostname }}"
+# ah_username: "admin"
+# ah_password: ""
+# ah_oauthtoken: ""
+# ah_validate_certs: false
+
+# force the installation of AAP even if it's already running
+aap_setup_inst_force: false

--- a/roles/aap_setup_install/meta/main.yml
+++ b/roles/aap_setup_install/meta/main.yml
@@ -1,0 +1,18 @@
+galaxy_info:
+  author: Eric Lavarde
+  description: Trigger installation of AAP given a prepared setup and inventory
+  company: Red Hat
+
+  license: MIT
+
+  min_ansible_version: 2.9
+
+  platforms:
+    - name: Fedora
+      versions:
+        - all
+        - 25
+
+  galaxy_tags: ['aap', 'ansible']
+
+dependencies: []

--- a/roles/aap_setup_install/tasks/main.yml
+++ b/roles/aap_setup_install/tasks/main.yml
@@ -1,0 +1,70 @@
+---
+# tasks file for aap_setup_install
+
+- name: Check Ansible Tower Running
+  uri:
+    url: "https://{{ controller_hostname }}/api/v2/ping/"
+    method: GET
+    user: "{{ controller_username }}"
+    password: "{{ controller_password }}"
+    validate_certs: "{{ controller_validate_certs }}"
+    force_basic_auth: true
+  register: __aap_setup_inst_ctl_check
+  ignore_errors: true
+  failed_when: false
+  when:
+    - automationcontroller in aap_setup_prep_inv_nodes
+    - not aap_setup_inst_force | bool
+
+- name: Check Automation Hub Running
+  uri:
+    url: "https://{{ ah_hostname }}/api/galaxy/"
+    method: GET
+    user: "{{ ah_username }}"
+    password: "{{ ah_password }}"
+    validate_certs: "{{ ah_validate_certs }}"
+    force_basic_auth: true
+  register: __aap_setup_inst_ah_check
+  ignore_errors: true
+  failed_when: false
+  when:
+    - automationhub in aap_setup_prep_inv_nodes
+    - not aap_setup_inst_force | bool
+
+- block:
+    - name: run the Ansible Automation Platform setup program
+      command: "{{ lookup('template', 'setup_sh.j2') }}"
+      args:
+        chdir: "{{ aap_setup_inst_setup_dir }}"
+      async: 10000
+      poll: 20
+      changed_when: false
+      # these will always run and will always report “changed” otherwise
+
+    - name: Wait for Ansible Tower to be running.
+      uri:
+        url: "https://{{ controller_hostname }}"
+        status_code: 200
+        validate_certs: "{{ controller_validate_certs }}"
+      register: __aap_setup_inst_result
+      until: __aap_setup_inst_result.status == 200
+      retries: 90
+      delay: 10
+      when: automationcontroller in aap_setup_prep_inv_nodes
+
+    - name: Wait for Automation Hub to be running.
+      uri:
+        url: "https://{{ ah_hostname }}/ui/"
+        status_code: 200
+        validate_certs: "{{ ah_validate_certs }}"
+      register: __aap_setup_inst_result_ah
+      until: __aap_setup_inst_result_ah.status == 200
+      retries: 90
+      delay: 10
+      when: automationhub in aap_setup_prep_inv_nodes
+  when: >
+    aap_setup_inst_force
+    or (automationcontroller in aap_setup_prep_inv_nodes
+        and __aap_setup_inst_ctl_check.status != 200)
+    or (automationhub in aap_setup_prep_inv_nodes
+        and __aap_setup_inst_ah_check.status != 200)

--- a/roles/aap_setup_install/tasks/main.yml
+++ b/roles/aap_setup_install/tasks/main.yml
@@ -7,13 +7,13 @@
     method: GET
     user: "{{ controller_username }}"
     password: "{{ controller_password }}"
-    validate_certs: "{{ controller_validate_certs }}"
+    validate_certs: "{{ controller_validate_certs | default(omit) }}"
     force_basic_auth: true
   register: __aap_setup_inst_ctl_check
   ignore_errors: true
   failed_when: false
   when:
-    - automationcontroller in aap_setup_prep_inv_nodes
+    - "'automationcontroller' in aap_setup_prep_inv_nodes"
     - not aap_setup_inst_force | bool
 
 - name: Check Automation Hub Running
@@ -22,13 +22,13 @@
     method: GET
     user: "{{ ah_username }}"
     password: "{{ ah_password }}"
-    validate_certs: "{{ ah_validate_certs }}"
+    validate_certs: "{{ ah_validate_certs | default(omit) }}"
     force_basic_auth: true
   register: __aap_setup_inst_ah_check
   ignore_errors: true
   failed_when: false
   when:
-    - automationhub in aap_setup_prep_inv_nodes
+    - "'automationhub' in aap_setup_prep_inv_nodes"
     - not aap_setup_inst_force | bool
 
 - block:
@@ -45,26 +45,26 @@
       uri:
         url: "https://{{ controller_hostname }}"
         status_code: 200
-        validate_certs: "{{ controller_validate_certs }}"
+        validate_certs: "{{ controller_validate_certs | default(omit) }}"
       register: __aap_setup_inst_result
       until: __aap_setup_inst_result.status == 200
       retries: 90
       delay: 10
-      when: automationcontroller in aap_setup_prep_inv_nodes
+      when: "'automationcontroller' in aap_setup_prep_inv_nodes"
 
     - name: Wait for Automation Hub to be running.
       uri:
         url: "https://{{ ah_hostname }}/ui/"
         status_code: 200
-        validate_certs: "{{ ah_validate_certs }}"
+        validate_certs: "{{ ah_validate_certs | default(omit) }}"
       register: __aap_setup_inst_result_ah
       until: __aap_setup_inst_result_ah.status == 200
       retries: 90
       delay: 10
-      when: automationhub in aap_setup_prep_inv_nodes
+      when: "'automationhub' in aap_setup_prep_inv_nodes"
   when: >
     aap_setup_inst_force
-    or (automationcontroller in aap_setup_prep_inv_nodes
+    or ('automationcontroller' in aap_setup_prep_inv_nodes
         and __aap_setup_inst_ctl_check.status != 200)
-    or (automationhub in aap_setup_prep_inv_nodes
+    or ('automationhub' in aap_setup_prep_inv_nodes
         and __aap_setup_inst_ah_check.status != 200)

--- a/roles/aap_setup_install/templates/setup_sh.j2
+++ b/roles/aap_setup_install/templates/setup_sh.j2
@@ -1,0 +1,6 @@
+{# template to generate the command line for the setup.sh installation script #}
+
+./setup.sh -i "{{ aap_setup_inst_inventory }}"
+{%- for varkey in aap_setup_inst_extra_vars %}
+ -e {{ varkey }}={{ aap_setup_inst_extra_vars[varkey] | quote }}
+{%- endfor -%}

--- a/roles/aap_setup_prepare/README.md
+++ b/roles/aap_setup_prepare/README.md
@@ -1,5 +1,5 @@
-Role Name
-=========
+aap\_setup\_prepare
+=================
 
 A role to prepare the installation of AAP 2.x, installing pre-requisites, unpacking the installation tarball and (optionally) writing the necessary inventory file.
 


### PR DESCRIPTION
### What does this PR do?

Allows to install AAP given a prepared setup directory and inventory

### How should this be tested?

The following playbook should work, given the proper inventory:

```yaml
- name: download and install AAP from the bastion
  hosts: bastion.*
  gather_facts: false
  become: false
  roles:
    - redhat_cop.tower_utilities.aap_setup_download
    - redhat_cop.tower_utilities.aap_setup_prepare
    - redhat_cop.tower_utilities.aap_setup_install
```


### Is there a relevant Issue open for this?

Nope, but discussed on chat

### Other Relevant info, PRs, etc.

n/a
