### PR TITLE
added ability to set the certs/keys content

### DIFF
--- a/roles/aap_certs/README.md
+++ b/roles/aap_certs/README.md
@@ -24,6 +24,15 @@ aap_certs_autohub_ssl_cert: "{{ playbook_dir }}/pulp.cert"
 aap_certs_autohub_ssl_key: "{{ playbook_dir }}/pulp.key"
 ```
 
+The content of the certifcates and keys can also be set rather than specifying a file. This is useful when you're using a secrets backend like HashiCorp Vault.
+
+```yaml
+aap_certs_controller_ssl_cert_content: "-----BEGIN CERTIFICATE----- xxxxxx -----END CERTIFICATE-----"
+aap_certs_controller_ssl_key_content: "-----BEGIN PRIVATE KEY----- xxxxxx -----END PRIVATE KEY-----"
+aap_certs_autohub_ssl_cert_content: "-----BEGIN CERTIFICATE----- xxxxxx -----END CERTIFICATE-----"
+aap_certs_autohub_ssl_key_content: "-----BEGIN PRIVATE KEY----- xxxxxx -----END PRIVATE KEY-----"
+```
+
 The following variable defines if the old certificates/keys should be backed-up:
 
 ```yaml

--- a/roles/aap_certs/defaults/main.yml
+++ b/roles/aap_certs/defaults/main.yml
@@ -9,6 +9,12 @@
 # aap_certs_controller_ssl_key: "{{ playbook_dir }}/tower.key"
 # aap_certs_autohub_ssl_cert: "{{ playbook_dir }}/pulp.cert"
 # aap_certs_autohub_ssl_key: "{{ playbook_dir }}/pulp.key"
+#
+# content of the certificates and keys
+# aap_certs_controller_ssl_cert_content: "-----BEGIN CERTIFICATE----- xxxxxx -----END CERTIFICATE-----"
+# aap_certs_controller_ssl_key_content: "-----BEGIN PRIVATE KEY----- xxxxxx -----END PRIVATE KEY-----"
+# aap_certs_autohub_ssl_cert_content: "-----BEGIN CERTIFICATE----- xxxxxx -----END CERTIFICATE-----"
+# aap_certs_autohub_ssl_key_content: "-----BEGIN PRIVATE KEY----- xxxxxx -----END PRIVATE KEY-----"
 
 # boolean to decide if the existing certificates are kept
 aap_certs_create_backup: false

--- a/roles/aap_certs/tasks/controller.yml
+++ b/roles/aap_certs/tasks/controller.yml
@@ -3,7 +3,8 @@
 - name: controller | copy cert into place
   become: true
   copy:
-    src: "{{ aap_certs_controller_ssl_cert }}"
+    src: "{{ aap_certs_controller_ssl_cert | default(omit) }}"
+    content: "{{ aap_certs_controller_ssl_cert_content | default(omit) }}"
     dest: "{{ aap_certs_controller_cert_dest }}"
     mode: u=rw,go=
     owner: root
@@ -14,7 +15,8 @@
 - name: controller | copy key into place
   become: true
   copy:
-    src: "{{ aap_certs_controller_ssl_key }}"
+    src: "{{ aap_certs_controller_ssl_key | default(omit) }}"
+    content: "{{ aap_certs_controller_ssl_key_content | default(omit) }}"
     dest: "{{ aap_certs_controller_key_dest }}"
     mode: u=rw,go=
     owner: root


### PR DESCRIPTION
### What does this PR do?
Adds the ability to set the cert/key content in the `aap_certs` role.

### How should this be tested?
Re-run the `aap_certs` role to validate idempotency.

### Is there a relevant Issue open for this?
Resolves #70 

### Other Relevant info, PRs, etc.
N/A
