### PR TITLE
Allow RHEL9 install

### DIFF
--- a/roles/aap_setup_download/README.md
+++ b/roles/aap_setup_download/README.md
@@ -17,9 +17,11 @@ The following input variables are required:
 It has no default value and _must_ be defined.
 * `aap_setup_down_version` defines the minor version to download (e.g. `2.1`), make sure you defines it as string and not as float!
 The default is the latest version available at time of writing.
+The default is the latest version available at time of writing.
 * `aap_setup_down_dest_dir` is the directory to where you want to download the tarball.
 It is by default the working directory `aap_setup_working_dir` also used by other roles of the collection, or ultimately `/var/tmp`.
 * `aap_setup_down_type` can be either `setup` or `setup-bundle`, depending which flavour of the tarball you want to download.
+* `aap_setup_rhel_version` defines the major RHEL version being used (currently 8 or 9). If you are gathering facts you possibly don't need to specify this as the role will attempt to work out the value required though you will if AAP will be installed on machines on a different OS than the installer will run on.
 
 The full path of the downloaded file is stored in the fact `aap_setup_down_installer_file` so that it can be used for extraction.
 

--- a/roles/aap_setup_download/README.md
+++ b/roles/aap_setup_download/README.md
@@ -17,11 +17,10 @@ The following input variables are required:
 It has no default value and _must_ be defined.
 * `aap_setup_down_version` defines the minor version to download (e.g. `2.1`), make sure you defines it as string and not as float!
 The default is the latest version available at time of writing.
-The default is the latest version available at time of writing.
 * `aap_setup_down_dest_dir` is the directory to where you want to download the tarball.
 It is by default the working directory `aap_setup_working_dir` also used by other roles of the collection, or ultimately `/var/tmp`.
 * `aap_setup_down_type` can be either `setup` or `setup-bundle`, depending which flavour of the tarball you want to download.
-* `aap_setup_rhel_version` defines the major RHEL version being used (currently 8 or 9). If you are gathering facts you possibly don't need to specify this as the role will attempt to work out the value required though you will if AAP will be installed on machines on a different OS than the installer will run on.
+* `aap_setup_rhel_version` defines the major RHEL version being used (currently 8 or 9). If you are gathering facts you possibly don't need to specify this as the role will attempt to work out the value required though you will if AAP will be installed on machines on a different OS than the installer will run on. Otherwise the default is 8.
 
 The full path of the downloaded file is stored in the fact `aap_setup_down_installer_file` so that it can be used for extraction.
 

--- a/roles/aap_setup_download/defaults/main.yml
+++ b/roles/aap_setup_download/defaults/main.yml
@@ -9,6 +9,9 @@
 # which version of the installer to download
 aap_setup_down_version: "2.1"
 
+# Which RHEL version are you using (8 or 9)
+aap_setup_rhel_version: "{{ ansible_distribution_major_version | default(8, true) }}"
+
 # where to download the setup installer file
 aap_setup_down_dest_dir: "{{ aap_setup_working_dir | default('/var/tmp') }}"
 

--- a/roles/aap_setup_download/vars/main.yml
+++ b/roles/aap_setup_download/vars/main.yml
@@ -1,6 +1,6 @@
 ---
 # vars file for aap_setup_download
-aap_setup_down_release: "ansible-automation-platform-{{ aap_setup_down_version }}-for-rhel-8-x86_64-files"
+aap_setup_down_release: "ansible-automation-platform-{{ aap_setup_down_version }}-for-rhel-{{ aap_setup_rhel_version }}-x86_64-files"
 aap_setup_down_token_url: "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token"
 aap_setup_down_images_url: "https://api.access.redhat.com/management/v1/images/cset/{{ aap_setup_down_release }}"
 ...


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
### What does this PR do?

Allows download of the RHEL9 version of Controller

### How should this be tested?
```
- hosts: localhost
  vars:
    aap_setup_down_offline_token: aaabbbccc0123
    aap_setup_down_version: "2.2"
    aap_setup_down_dest_dir: .
    aap_setup_down_type: setup
    aap_setup_rhel_version: "9"
  roles:
    - ../roles/aap_setup_download
```

### Is there a relevant Issue open for this?

resolves #76 

