### PR TITLE
update hostnames to inventory names

### DIFF
--- a/roles/aap_setup_download/defaults/main.yml
+++ b/roles/aap_setup_download/defaults/main.yml
@@ -7,7 +7,7 @@
 # aap_setup_down_offline_token:
 
 # which version of the installer to download
-aap_setup_down_version: "2.1"
+aap_setup_down_version: "2.2"
 
 # Which RHEL version are you using (8 or 9)
 aap_setup_rhel_version: "{{ ansible_distribution_major_version | default(8, true) }}"

--- a/roles/aap_setup_install/defaults/main.yml
+++ b/roles/aap_setup_install/defaults/main.yml
@@ -1,6 +1,10 @@
 ---
 # defaults file for aap_setup_install
 
+# Hostnames for check
+controller_hostname: aap_setup_prep_inv_nodes['automationcontroller'][0]
+ah_hostname: aap_setup_prep_inv_nodes['automationhub'][0]
+
 # where is the setup directory
 aap_setup_inst_setup_dir: "{{ aap_setup_prep_setup_dir }}"
 

--- a/roles/aap_setup_install/tasks/main.yml
+++ b/roles/aap_setup_install/tasks/main.yml
@@ -3,11 +3,11 @@
 
 - name: Check Ansible Tower Running
   uri:
-    url: "https://{{ controller_hostname }}/api/v2/ping/"
+    url: "https://{{ controller_hostname }}/"
     method: GET
-    user: "{{ controller_username }}"
-    password: "{{ controller_password }}"
-    validate_certs: "{{ controller_validate_certs | default(omit) }}"
+    user: admin
+    password: "{{ aap_setup_prep_inv_vars.all.admin_password }}"
+    validate_certs: "{{ controller_validate_certs | default('false') }}"
     force_basic_auth: true
   register: __aap_setup_inst_ctl_check
   ignore_errors: true
@@ -20,9 +20,9 @@
   uri:
     url: "https://{{ ah_hostname }}/api/galaxy/"
     method: GET
-    user: "{{ ah_username }}"
-    password: "{{ ah_password }}"
-    validate_certs: "{{ ah_validate_certs | default(omit) }}"
+    user: admin
+    password: "{{ aap_setup_prep_inv_vars.all.automationhub_admin_password }}"
+    validate_certs: "{{ controller_validate_certs | default('false') }}"
     force_basic_auth: true
   register: __aap_setup_inst_ah_check
   ignore_errors: true
@@ -43,7 +43,7 @@
 
     - name: wait for automation controller to be running
       uri:  # use the first host from the list if no hostname is defined
-        url: "https://{{ controller_hostname | default((aap_setup_prep_inv_nodes['automationcontroller'].keys() | list)[0]) }}"
+        url: "https://{{ controller_hostname }}/"
         status_code: 200
         validate_certs: "{{ controller_validate_certs | default(omit) }}"
       register: __aap_setup_inst_result
@@ -54,7 +54,7 @@
 
     - name: wait for automation hub to be running
       uri:  # use the first host from the list if no hostname is defined
-        url: "https://{{ ah_hostname | default((aap_setup_prep_inv_nodes['automationhub'].keys() | list)[0]) }}/ui/"
+        url: "https://{{ ah_hostname }}/api/galaxy/"
         status_code: 200
         validate_certs: "{{ ah_validate_certs | default(omit) }}"
       register: __aap_setup_inst_result_ah

--- a/roles/aap_setup_prepare/defaults/main.yml
+++ b/roles/aap_setup_prepare/defaults/main.yml
@@ -137,6 +137,5 @@ aap_setup_prep_inv_secrets: {}
 #     #isolated_key_generation: true
 
 # list of fixes to apply to the installation scripts, use with CAUTION!
-aap_setup_prep_fixes:
-  - aap_1413
+aap_setup_prep_fixes: []
 ...


### PR DESCRIPTION
### What does this PR do?
This updates the hostnames to be pulled from the variables set for the install, rather then vars that are used no where else. 
It also sets the default download version to 2.2

### How should this be tested?
It has been tested and works with the current deployment variables.

Fixes Issue #78
