### PR TITLE
Add AAP-4555 setup.log fix to aap_setup_install

### DIFF
--- a/roles/aap_setup_install/defaults/main.yml
+++ b/roles/aap_setup_install/defaults/main.yml
@@ -63,7 +63,7 @@ aap_setup_inst_extra_vars: {}
 aap_setup_inst_force: false
 
 # list of fixes to apply before starting the actual installation,
-# empty by default, possible values are listed below
-aap_setup_inst_fixes: []
-# - aap_4555  # setup.log is only saved on first call as non-root
+# review before bumping up the default AAP version
+aap_setup_inst_fixes:
+  - aap_4555  # setup.log is only saved on first call as non-root (2.2.0)
 ...

--- a/roles/aap_setup_install/defaults/main.yml
+++ b/roles/aap_setup_install/defaults/main.yml
@@ -61,4 +61,9 @@ aap_setup_inst_extra_vars: {}
 
 # force the installation of AAP even if it's already running
 aap_setup_inst_force: false
+
+# list of fixes to apply before starting the actual installation,
+# empty by default, possible values are listed below
+aap_setup_inst_fixes: []
+# - aap_4555  # setup.log is only saved on first call as non-root
 ...

--- a/roles/aap_setup_install/tasks/fixes/aap_4555.yml
+++ b/roles/aap_setup_install/tasks/fixes/aap_4555.yml
@@ -6,6 +6,7 @@
   ansible.builtin.stat:
     path: "{{ aap_setup_inst_setup_dir }}/setup.log"
   register: __aap_setup_inst_log
+
 - name: AAP_4555 | create a backup of setup.log if it exists
   ansible.builtin.copy:
     src: /dev/null
@@ -14,6 +15,7 @@
     remote_src: true
     mode: 0664
   when: __aap_setup_inst_log.stat.exists
+
 - name: AAP_4555 | make sure setup.log doesn't exist
   ansible.builtin.file:
     path: "{{ aap_setup_inst_setup_dir }}/setup.log"

--- a/roles/aap_setup_install/tasks/fixes/aap_4555.yml
+++ b/roles/aap_setup_install/tasks/fixes/aap_4555.yml
@@ -12,8 +12,10 @@
     dest: "{{ aap_setup_inst_setup_dir }}/setup.log"
     backup: true  # we use the backup feature of copy to save setup.log
     remote_src: true
+    mode: 0664
   when: __aap_setup_inst_log.stat.exists
 - name: AAP_4555 | make sure setup.log doesn't exist
   ansible.builtin.file:
     path: "{{ aap_setup_inst_setup_dir }}/setup.log"
     state: absent
+...

--- a/roles/aap_setup_install/tasks/fixes/aap_4555.yml
+++ b/roles/aap_setup_install/tasks/fixes/aap_4555.yml
@@ -1,0 +1,19 @@
+---
+# Fix for https://issues.redhat.com/browse/AAP-4555 - it'll move away the
+# setup.log before starting the installation
+
+- name: AAP_4555 | check if setup.log does exist
+  ansible.builtin.stat:
+    path: "{{ aap_setup_inst_setup_dir }}/setup.log"
+  register: __aap_setup_inst_log
+- name: AAP_4555 | create a backup of setup.log if it exists
+  ansible.builtin.copy:
+    src: /dev/null
+    dest: "{{ aap_setup_inst_setup_dir }}/setup.log"
+    backup: true  # we use the backup feature of copy to save setup.log
+    remote_src: true
+  when: __aap_setup_inst_log.stat.exists
+- name: AAP_4555 | make sure setup.log doesn't exist
+  ansible.builtin.file:
+    path: "{{ aap_setup_inst_setup_dir }}/setup.log"
+    state: absent

--- a/roles/aap_setup_install/tasks/main.yml
+++ b/roles/aap_setup_install/tasks/main.yml
@@ -1,6 +1,11 @@
 ---
 # tasks file for aap_setup_install
 
+- name: apply relevant fixes / workarounds
+  include_tasks:
+    file: "fixes/{{ item }}.yml"
+  loop: "{{ aap_setup_inst_fixes }}"
+
 - name: Check Ansible Tower Running
   uri:
     url: "https://{{ controller_hostname }}/"


### PR DESCRIPTION
### What does this PR do?

setup.log is moved away before a new installation starts.
It's not by default, the new variable aap_setup_inst_fixes needs to contain aap_4555

### How should this be tested?

Just start twice the same installation with pre-existing setup.log file and see how a new setup.log is created.

### Is there a relevant Issue open for this?

resolves #80 

### Other Relevant info, PRs, etc

https://issues.redhat.com/browse/AAP-4555
