### PR TITLE
Correct controller_hostname and ah_hostname within aap_setup_install …

### DIFF
--- a/roles/aap_setup_install/defaults/main.yml
+++ b/roles/aap_setup_install/defaults/main.yml
@@ -2,8 +2,8 @@
 # defaults file for aap_setup_install
 
 # Hostnames for check
-controller_hostname: aap_setup_prep_inv_nodes['automationcontroller'][0]
-ah_hostname: aap_setup_prep_inv_nodes['automationhub'][0]
+controller_hostname: "{{ aap_setup_prep_inv_nodes['automationcontroller'][0] }}"
+ah_hostname: "{{ aap_setup_prep_inv_nodes['automationhub'][0] }}"
 
 # where is the setup directory
 aap_setup_inst_setup_dir: "{{ aap_setup_prep_setup_dir }}"


### PR DESCRIPTION
…defaults file

<!-- markdownlint-disable MD041 -->
### What does this PR do?

Variabilised controller_hostname and ah_name within the defaults file of the aap_setup_install role. 

### How should this be tested?

This should be tested by running a playbook that uses the role aap_setup_download (assuming the installer isn't already downloaded), aap_setup_prepare, and aap_setup_install on a server without AAP2 installed. The playbook should fully complete running, and the task 'wait for automation controller to be running' should return an 'ok' message.

### Is there a relevant Issue open for this?

Resolves 'controller_hostname and ah_hostname within aap_setup_install not variabilised' #90 

https://github.com/redhat-cop/aap_utilities/issues/90

### Other Relevant info, PRs, etc

N/A
