### PR TITLE
Parametrize OCP controller install

### DIFF
--- a/roles/aap_ocp_install/README.md
+++ b/roles/aap_ocp_install/README.md
@@ -11,31 +11,31 @@ In addition the kubernetes.core and redhat.openshift Ansible collections are req
 
 A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
 
-| Variable Name              | Default Value | Required | Description                                                            |
-|----------------------------|:-------------:|:--------:|------------------------------------------------------------------------|
-| aap_ocp_install_namespace  | None          |          |                                                                        |
-| aap_ocp_install_connection | None          | Yes      | Dictionary containing keys defined in the `connection variables table` |
-| aap_ocp_install_operator   | None          | Yes*     | Dictionary containing keys defined in the `operator variables table`   |
-| aap_ocp_install_controller | None          | Yes*     | Dictionary containing keys defined in the `controller variables table` |
-| aap_ocp_install_hub        | None          | Yes*     | Dictionary containing keys defined in the `hub variables table`        |
+| Variable Name              | Required | Default Value | Description                                                            |
+|----------------------------|:--------:|---------------|------------------------------------------------------------------------|
+| aap_ocp_install_namespace  | Yes      | None          | Namespace to create operator, controller, and hub in                   |
+| aap_ocp_install_connection | Yes      | None          | Dictionary containing keys defined in the `connection variables table` |
+| aap_ocp_install_operator   | Yes*     | None          | Dictionary containing keys defined in the `operator variables table`   |
+| aap_ocp_install_controller | Yes*     | None          | Dictionary containing keys defined in the `controller variables table` |
+| aap_ocp_install_hub        | Yes*     | None          | Dictionary containing keys defined in the `hub variables table`        |
 
 \* Variable and required keys must be defined when no tags are specified or the type of tag is specified (e.g. `--tags controller` requires the aap_ocp_install_controller variable be defined.)
 
 ### aap_ocp_install_connection keys
 
-| Key Name       | Default Value | Required | Description                                                  |
-|----------------|:-------------:|:--------:|--------------------------------------------------------------|
-| host           | None          | Yes      | OCP cluster to create the AAP objects in                     |
-| username       | None          | Yes      | Username to use for authenticating with OCP                  |
-| password       | None          | Yes      | Password to use for authenticating with OCP                  |
-| validate_certs | None          |          | Validate SSL certificates. Valid values are: `true`, `false` |
+| Key Name       | Required | Default Value | Description                                                  |
+|----------------|:--------:|---------------|--------------------------------------------------------------|
+| host           | Yes      | None          | OCP cluster to create the AAP objects in                     |
+| username       | Yes      | None          | Username to use for authenticating with OCP                  |
+| password       | Yes      | None          | Password to use for authenticating with OCP                  |
+| validate_certs |          | None          | Validate SSL certificates. Valid values are: `true`, `false` |
 
 ### aap_ocp_install_operator keys
 
-| Key Name | Default Value | Required | Description                                                   |
-|----------|:-------------:|:--------:|---------------------------------------------------------------|
-| channel  | None          | Yes      | Channel to subscribe (e.g. stable-2.2)                        |
-| approval | Automatic     |          | Update approval method. Valid values are Automatic or Manual. |
+| Key Name | Required | Default Value | Description                                                         |
+|----------|:--------:|---------------|---------------------------------------------------------------------|
+| channel  | Yes      | None          | Channel to subscribe (e.g. stable-2.2 or stable-2.2-cluster-scoped) |
+| approval |          | Automatic     | Update approval method. Valid values are Automatic or Manual.       |
 
 > ℹ️ **NOTE**
 >
@@ -43,18 +43,25 @@ A description of the settable variables for this role should go here, including 
 
 ### aap_ocp_install_controller keys
 
-| Key Name      | Default Value | Required | Description                                     |
-|---------------|:-------------:|:--------:|-------------------------------------------------|
-| instance_name | None          | Yes      | Name of the controller instance to create       |
-| replicas      | None          |          | How many replicas to create. Default: 1         |
-| link_text     | None          |          | Text used for creating the OCP application link |
+| Key Name                     | Required | Default Value                           | Description                                                                                                            |
+|------------------------------|:--------:|-----------------------------------------|------------------------------------------------------------------------------------------------------------------------|
+| instance_name                | Yes      | None                                    | Name of the controller instance to create                                                                              |
+| namespace                    |          | None                                    | Name of the namespace to create the controller instance in. If not specified `aap_ocp_install_namespace` will be used. |
+| admin_user                   |          | admin                                   | Username to use for the admin account                                                                                  |
+| replicas                     |          | 1                                       | How many replicas to create.                                                                                           |
+| garbage_collect_secrets      |          | false                                   | Whether or not to remove secrets upon instance removal                                                                 |
+| image_pull_policy            |          | IfNotPresent                            | The image pull policy                                                                                                  |
+| create_preload_data          |          | true                                    | Whether or not to preload data upon instance creation                                                                  |
+| projects_persistence         |          | false                                   | Whether or not the /var/lib/projects directory will be persistent                                                      |
+| projects_storage_size        |          | 8Gi                                     | Size of /var/lib/projects persistent volume claim (PVC)                                                                |
+| link_text                    |          | Automation Controller (<INSTANCE_NAME>) | Text used for creating the OCP application link                                                                        |
 
-### aap_ocp_install_hub keys
+| ### aap_ocp_install_hub keys |### aap_ocp_install_hub keys
 
-| Key Name      | Default Value | Required | Description                                     |
-|---------------|:-------------:|:--------:|-------------------------------------------------|
-| instance_name | None          | Yes      | Name of the hub instance to create              |
-| link_text     | None          |          | Text used for creating the OCP application link |
+| Key Name      | Required | Default Value                    | Description                                     |
+|---------------|:--------:|----------------------------------|-------------------------------------------------|
+| instance_name | Yes      | None                             | Name of the hub instance to create              |
+| link_text     |          | Automation Hub (<INSTANCE_NAME>) | Text used for creating the OCP application link |
 
 ## Dependencies
 

--- a/roles/aap_ocp_install/tasks/initialization.yml
+++ b/roles/aap_ocp_install/tasks/initialization.yml
@@ -13,6 +13,9 @@
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
     validate_certs: "{{ aap_ocp_install_ocp_connection['validate_certs'] | default(omit) }}"
     state: present
-    resource_definition: "{{ lookup('template', 'namespace.yaml.j2') | from_yaml }}"
+    resource_definition: "{{ lookup('ansible.builtin.template', 'namespace.yaml.j2', template_vars=ns_vars) | from_yaml }}"
     apply: true
+  vars:
+    ns_vars:
+      ns_name: "{{ aap_ocp_install_namespace }}"
 ...

--- a/roles/aap_ocp_install/tasks/install-controller.yml
+++ b/roles/aap_ocp_install/tasks/install-controller.yml
@@ -1,4 +1,18 @@
 ---
+- name: Create controller namespace
+  kubernetes.core.k8s:
+    host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
+    api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
+    validate_certs: "{{ aap_ocp_install_ocp_connection['validate_certs'] | default(omit) }}"
+    state: present
+    resource_definition: "{{ lookup('ansible.builtin.template', 'namespace.yaml.j2', template_vars=ns_vars) | from_yaml }}"
+    apply: true
+  vars:
+    ns_vars:
+      ns_name: "{{ aap_ocp_install_controller['namespace'] }}"
+  when:
+    - aap_ocp_install_controller['namespace'] is defined
+
 - name: Create automation controller instance
   kubernetes.core.k8s:
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
@@ -16,7 +30,7 @@
     kind: Route
     name: "{{ aap_ocp_install_controller['instance_name']  | mandatory }}"
     api_version: route.openshift.io/v1
-    namespace: "{{ aap_ocp_install_namespace | mandatory }}"
+    namespace: "{{ aap_ocp_install_controller['namespace'] | default(aap_ocp_install_namespace) | mandatory }}"
   register: __aap_ocp_install_controller_route_result
   until: __aap_ocp_install_controller_route_result['resources']
   retries: 60  # Wait for 15 minutes (60*15/60)

--- a/roles/aap_ocp_install/tasks/pre-validate-controller.yml
+++ b/roles/aap_ocp_install/tasks/pre-validate-controller.yml
@@ -1,0 +1,141 @@
+---
+- name: Ensure controller instance name variable is set (block)
+  block:
+    - name: Ensure controller instance name variable is set
+      ansible.builtin.assert:
+        that:
+          - aap_ocp_install_controller['instance_name'] | default('', true) | length > 0
+        quiet: true
+  rescue:
+    - name: Update validation errors fact - controller instance_name
+      ansible.builtin.set_fact:
+        __aap_ocp_install_prevalidate_errors: >
+          {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_controller['instance_name'] must be set"] }}
+
+- name: Ensure controller admin username variable is set (block)
+  block:
+    - name: Ensure controller admin username variable is set
+      ansible.builtin.assert:
+        that:
+          - aap_ocp_install_controller['admin_user'] | default('', true) | length > 0
+        quiet: true
+  rescue:
+    - name: Update validation errors fact - controller admin_user
+      ansible.builtin.set_fact:
+        __aap_ocp_install_prevalidate_errors: >
+          {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_controller['admin_user'] must be a non-empty string"] }}
+  when: aap_ocp_install_controller['admin_user'] is defined
+
+- name: Ensure controller namespace variable is set (block)
+  block:
+    - name: Ensure controller namespace variable is set
+      ansible.builtin.assert:
+        that:
+          - aap_ocp_install_controller['namespace'] | default("", true) | regex_search('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')
+        quiet: true
+  rescue:
+    - name: Update validation errors fact - namespace
+      ansible.builtin.set_fact:
+        __aap_ocp_install_prevalidate_errors: >
+          {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_controller['namespace'] must be a lowercase RFC 1123 label consisting of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'"] }}
+  when: aap_ocp_install_controller['namespace'] is defined
+
+- name: Ensure controller link text variable is set (block)
+  block:
+    - name: Ensure controller link text variable is set
+      ansible.builtin.assert:
+        that:
+          - aap_ocp_install_controller['link_text'] | default('', true) | length > 0
+        quiet: true
+  rescue:
+    - name: Update validation errors fact - controller link_text
+      ansible.builtin.set_fact:
+        __aap_ocp_install_prevalidate_errors: >
+          {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_controller['link_text'] must be a non-empty string"] }}
+  when: aap_ocp_install_controller['link_text'] is defined
+
+- name: Ensure controller image pull policy is valid (block)
+  block:
+    - name: Ensure controller image pull policy is valid
+      ansible.builtin.assert:
+        that:
+          - aap_ocp_install_controller['image_pull_policy'] is in ['IfNotPresent', 'Always', 'Never']
+        quiet: true
+  rescue:
+    - name: Update validation errors fact - controller image_pull_policy
+      ansible.builtin.set_fact:
+        __aap_ocp_install_prevalidate_errors: >
+          {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_controller['image_pull_policy'] must be one of: IfNotPresent, Always, or Never"] }}
+  when: aap_ocp_install_controller['image_pull_policy'] is defined
+
+- name: Ensure controller create preload data is valid (block)
+  block:
+    - name: Ensure controller create preload data is valid
+      ansible.builtin.assert:
+        that:
+          - (aap_ocp_install_controller['create_preload_data'] | string | lower) is in ['true', 'false']
+        quiet: true
+  rescue:
+    - name: Update validation errors fact - controller create_preload_data
+      ansible.builtin.set_fact:
+        __aap_ocp_install_prevalidate_errors: >
+          {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_controller['create_preload_data'] must be one of: true or false"] }}
+  when: aap_ocp_install_controller['create_preload_data'] is defined
+
+- name: Ensure controller garbage collect secrets is valid (block)
+  block:
+    - name: Ensure controller garbage collect secrets is valid
+      ansible.builtin.assert:
+        that:
+          - (aap_ocp_install_controller['garbage_collect_secrets'] | string | lower) is in ['true', 'false']
+        quiet: true
+  rescue:
+    - name: Update validation errors fact - controller garbage_collect_secrets
+      ansible.builtin.set_fact:
+        __aap_ocp_install_prevalidate_errors: >
+          {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_controller['garbage_collect_secrets'] must be one of: true or false"] }}
+  when: aap_ocp_install_controller['garbage_collect_secrets'] is defined
+
+- name: Ensure controller projects persistence is valid (block)
+  block:
+    - name: Ensure controller projects persistence is valid
+      ansible.builtin.assert:
+        that:
+          - (aap_ocp_install_controller['projects_persistence'] | string | lower) is in ['true', 'false']
+        quiet: true
+  rescue:
+    - name: Update validation errors fact - controller projects_persistence
+      ansible.builtin.set_fact:
+        __aap_ocp_install_prevalidate_errors: >
+          {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_controller['projects_persistence'] must be one of: true or false"] }}
+  when: aap_ocp_install_controller['projects_persistence'] is defined
+
+- name: Ensure controller replicas is valid (block)
+  block:
+    - name: Ensure controller replicas is valid
+      ansible.builtin.assert:
+        that:
+          - (aap_ocp_install_controller['replicas'] | int) > 0
+        quiet: true
+  rescue:
+    - name: Update validation errors fact - controller replicas
+      ansible.builtin.set_fact:
+        __aap_ocp_install_prevalidate_errors: >
+          {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_controller['replicas'] must be a number greater than 0"] }}
+  when: aap_ocp_install_controller['replicas'] is defined
+
+- name: Ensure controller projects storage size is valid (block)
+  block:
+    - name: Ensure controller projects storage size is valid
+      ansible.builtin.assert:
+        that:
+          - (aap_ocp_install_controller['projects_storage_size'] | regex_replace('^(?P<size>[0-9]+)(?P<si>Ki|K|Mi|M|Gi|G|Ti|T|Pi|P|Ei|E)$', '\\g<size>') | int) > 0
+          - (aap_ocp_install_controller['projects_storage_size'] | regex_replace('^(?P<size>[0-9]+)(?P<si>Ki|K|Mi|M|Gi|G|Ti|T|Pi|P|Ei|E)$', '\\g<si>')) is in ['Ki','K','Mi','M','Gi','G','Ti','T','Pi','P','Ei','E']
+        quiet: true
+  rescue:
+    - name: Update validation errors fact - projects_storage_size replicas
+      ansible.builtin.set_fact:
+        __aap_ocp_install_prevalidate_errors: >
+          {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_controller['projects_storage_size'] must be a number greater than 0 with a size (e.g. 12Gi or 10000M)"] }}
+  when: aap_ocp_install_controller['projects_storage_size'] is defined
+...

--- a/roles/aap_ocp_install/tasks/pre-validate.yml
+++ b/roles/aap_ocp_install/tasks/pre-validate.yml
@@ -46,21 +46,19 @@
     - name: Ensure OpenShift namespace variable is set
       ansible.builtin.assert:
         that:
-          - aap_ocp_install_namespace is defined
-          - aap_ocp_install_namespace | default("", true) | length > 0
+          - aap_ocp_install_namespace | default("", true) | regex_search('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')
         quiet: true
   rescue:
     - name: Update validation errors fact - namespace
       ansible.builtin.set_fact:
         __aap_ocp_install_prevalidate_errors: >
-          {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_namespace must be set"] }}
+          {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_namespace must be a lowercase RFC 1123 label consisting of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'"] }}
 
 - name: Ensure operator channel variable is set (block)
   block:
     - name: Ensure operator channel variable is set
       ansible.builtin.assert:
         that:
-          - aap_ocp_install_operator['channel'] is defined
           - aap_ocp_install_operator['channel'] | default('', true) | length > 0
         quiet: true
   rescue:
@@ -71,28 +69,17 @@
       when:
         - ( 'operator' in ansible_run_tags ) or ( 'all' in ansible_run_tags )
 
-- name: Ensure controller instance name variable is set (block)
-  block:
-    - name: Ensure controller instance name variable is set
-      ansible.builtin.assert:
-        that:
-          - aap_ocp_install_controller['instance_name'] is defined
-          - aap_ocp_install_controller['instance_name'] | default('', true) | length > 0
-        quiet: true
-  rescue:
-    - name: Update validation errors fact - controller instance_name
-      ansible.builtin.set_fact:
-        __aap_ocp_install_prevalidate_errors: >
-          {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_controller['instance_name'] must be set"] }}
-      when:
-        - ( 'controller' in ansible_run_tags ) or ( 'all' in ansible_run_tags )
+- name: Ensure controller variables are set
+  ansible.builtin.include_tasks:
+    file: pre-validate-controller.yml
+  when:
+    - ( 'controller' in ansible_run_tags ) or ( 'all' in ansible_run_tags )
 
 - name: Ensure hub instance name variable is set (block)
   block:
     - name: Ensure hub instance name variable is set
       ansible.builtin.assert:
         that:
-          - aap_ocp_install_hub['instance_name'] is defined
           - aap_ocp_install_hub['instance_name'] | default('', true) | length > 0
         quiet: true
   rescue:
@@ -104,8 +91,10 @@
         - ( 'hub' in ansible_run_tags ) or ( 'all' in ansible_run_tags )
 
 - name: Ensure no validation errors found
-  ansible.builtin.assert:
-    that:
-      - (__aap_ocp_install_prevalidate_errors | length == 0)
-    fail_msg: "The following errors must be fixed to continue: {{ __aap_ocp_install_prevalidate_errors | join(', ') }}"
+  ansible.builtin.debug:
+    msg:
+      - "The following errors must be fixed to continue:"
+      - "{{ __aap_ocp_install_prevalidate_errors }}"
+  failed_when: (__aap_ocp_install_prevalidate_errors | length) > 0
+  when: (__aap_ocp_install_prevalidate_errors | length) > 0
 ...

--- a/roles/aap_ocp_install/templates/controller/instance.yaml.j2
+++ b/roles/aap_ocp_install/templates/controller/instance.yaml.j2
@@ -3,15 +3,13 @@ apiVersion: automationcontroller.ansible.com/v1beta1
 kind: AutomationController
 metadata:
   name: {{ aap_ocp_install_controller['instance_name'] }}
-  namespace: {{ aap_ocp_install_namespace }}
+  namespace: {{ aap_ocp_install_controller['namespace'] | default(aap_ocp_install_namespace) }}
 spec:
-  create_preload_data: true
-  route_tls_termination_mechanism: Edge
-  garbage_collect_secrets: true
-  ingress_type: Route
-  image_pull_policy: IfNotPresent
-  task_privileged: false
-  projects_persistence: false
-  replicas: {{ aap_ocp_install_controller['replicas'] | default('1') }}
-  admin_user: admin
+  create_preload_data: {{ aap_ocp_install_controller['create_preload_data'] | default(true) | bool }}
+  garbage_collect_secrets: {{ aap_ocp_install_controller['garbage_collect_secrets'] | default(false) | bool }}
+  image_pull_policy: {{ aap_ocp_install_controller['image_pull_policy'] | default('IfNotPresent') }}
+  projects_persistence: {{ aap_ocp_install_controller['projects_persistence'] | default(false) | bool }}
+  projects_storage_size: {{ aap_ocp_install_controller['projects_storage_size'] | default('8Gi') }}
+  replicas: {{ aap_ocp_install_controller['replicas'] | default(1) | int }}
+  admin_user: {{ aap_ocp_install_controller['admin_user'] | default('admin') }}
 ...

--- a/roles/aap_ocp_install/templates/namespace.yaml.j2
+++ b/roles/aap_ocp_install/templates/namespace.yaml.j2
@@ -2,5 +2,5 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-    name: {{ aap_ocp_install_namespace }}
+    name: {{ ns_name }}
 ...


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
### What does this PR do?

Adds paramatization to all settings for the controller installation on OCP via the operator. Also introduces the ability to have the controller installed in a different namespace than the operator (useful for when the operator is cluster-scoped).

The output for errors found during validation is also easier to read. 

### How should this be tested?

Create a playbook to run the `aap_ocp_install` role with appropriate variables set (see the README.md in the role).

### Is there a relevant Issue open for this?

No

### Other Relevant info, PRs, etc

None