### PR TITLE
Allow individual components to be installed on OCP

### DIFF
--- a/roles/aap_ocp_install/README.md
+++ b/roles/aap_ocp_install/README.md
@@ -19,7 +19,8 @@ A description of the settable variables for this role should go here, including 
 | aap_ocp_install_controller | Yes*     | None          | Dictionary containing keys defined in the `controller variables table` |
 | aap_ocp_install_hub        | Yes*     | None          | Dictionary containing keys defined in the `hub variables table`        |
 
-\* Variable and required keys must be defined when no tags are specified or the type of tag is specified (e.g. `--tags controller` requires the aap_ocp_install_controller variable be defined.)
+\* Variable and required keys must be defined when the type of tag is specified (e.g. `--tags controller` requires the aap_ocp_install_controller variable be defined).
+If the variable is omitted the corresponding component will not be installed (e.g. if only aap_ocp_install_hub variable is defined then the operator and controller installation will be skipped)
 
 ### aap_ocp_install_connection keys
 

--- a/roles/aap_ocp_install/tasks/main.yml
+++ b/roles/aap_ocp_install/tasks/main.yml
@@ -23,6 +23,7 @@
     apply:
       tags:
         - operator
+  when: aap_ocp_install_operator is defined
   tags:
     - operator
 
@@ -32,6 +33,7 @@
     apply:
       tags:
         - controller
+  when: aap_ocp_install_controller is defined
   tags:
     - controller
 
@@ -41,6 +43,7 @@
     apply:
       tags:
         - hub
+  when: aap_ocp_install_hub is defined
   tags:
     - hub
 ...

--- a/roles/aap_ocp_install/tasks/pre-validate-hub.yml
+++ b/roles/aap_ocp_install/tasks/pre-validate-hub.yml
@@ -1,0 +1,14 @@
+---
+- name: Ensure hub instance name variable is set (block)
+  block:
+    - name: Ensure hub instance name variable is set
+      ansible.builtin.assert:
+        that:
+          - aap_ocp_install_hub['instance_name'] | default('', true) | length > 0
+        quiet: true
+  rescue:
+    - name: Update validation errors fact - hub instance_name
+      ansible.builtin.set_fact:
+        __aap_ocp_install_prevalidate_errors: >
+          {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_hub['instance_name'] must be set"] }}
+...

--- a/roles/aap_ocp_install/tasks/pre-validate-operator.yml
+++ b/roles/aap_ocp_install/tasks/pre-validate-operator.yml
@@ -1,0 +1,14 @@
+---
+- name: Ensure operator channel variable is set (block)
+  block:
+    - name: Ensure operator channel variable is set
+      ansible.builtin.assert:
+        that:
+          - aap_ocp_install_operator['channel'] | default('', true) | length > 0
+        quiet: true
+  rescue:
+    - name: Update validation errors fact - channel
+      ansible.builtin.set_fact:
+        __aap_ocp_install_prevalidate_errors: >
+          {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_operator['channel'] must be set"] }}
+...

--- a/roles/aap_ocp_install/tasks/pre-validate.yml
+++ b/roles/aap_ocp_install/tasks/pre-validate.yml
@@ -54,41 +54,23 @@
         __aap_ocp_install_prevalidate_errors: >
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_namespace must be a lowercase RFC 1123 label consisting of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'"] }}
 
-- name: Ensure operator channel variable is set (block)
-  block:
-    - name: Ensure operator channel variable is set
-      ansible.builtin.assert:
-        that:
-          - aap_ocp_install_operator['channel'] | default('', true) | length > 0
-        quiet: true
-  rescue:
-    - name: Update validation errors fact - channel
-      ansible.builtin.set_fact:
-        __aap_ocp_install_prevalidate_errors: >
-          {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_operator['channel'] must be set"] }}
-      when:
-        - ( 'operator' in ansible_run_tags ) or ( 'all' in ansible_run_tags )
+- name: Ensure operator variables are set
+  ansible.builtin.include_tasks:
+    file: pre-validate-operator.yml
+  when:
+    - ( 'operator' in ansible_run_tags ) or ( 'all' in ansible_run_tags and aap_ocp_install_operator is defined )
 
 - name: Ensure controller variables are set
   ansible.builtin.include_tasks:
     file: pre-validate-controller.yml
   when:
-    - ( 'controller' in ansible_run_tags ) or ( 'all' in ansible_run_tags )
+    - ( 'controller' in ansible_run_tags ) or ( 'all' in ansible_run_tags and aap_ocp_install_controller is defined )
 
-- name: Ensure hub instance name variable is set (block)
-  block:
-    - name: Ensure hub instance name variable is set
-      ansible.builtin.assert:
-        that:
-          - aap_ocp_install_hub['instance_name'] | default('', true) | length > 0
-        quiet: true
-  rescue:
-    - name: Update validation errors fact - hub instance_name
-      ansible.builtin.set_fact:
-        __aap_ocp_install_prevalidate_errors: >
-          {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_hub['instance_name'] must be set"] }}
-      when:
-        - ( 'hub' in ansible_run_tags ) or ( 'all' in ansible_run_tags )
+- name: Ensure hub variables are set
+  ansible.builtin.include_tasks:
+    file: pre-validate-hub.yml
+  when:
+    - ( 'hub' in ansible_run_tags ) or ( 'all' in ansible_run_tags and aap_ocp_install_hub is defined )
 
 - name: Ensure no validation errors found
   ansible.builtin.debug:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
### What does this PR do?

Allow each component to be individually installed (operator, controller, hub).

As an example the below playbook will now execute without generating an error for missing hub configuration info and successfully installs the operator and controller.

```
- name: Install AAP on OCP playbook
  hosts: localhost
  gather_facts: false

  vars:
    aap_ocp_install_ocp_connection:
      host: "https://api.crc.testing:6443"
      username: kubeadmin
      password: <REDACTED>
      validate_certs: false
    aap_ocp_install_namespace: aap-test
    aap_ocp_install_operator:
      channel: "stable-2.2"
    aap_ocp_install_controller:
      instance_name: automationcontroller

  roles:
    - redhat_cop.aap_utilities.aap_ocp_install
 ```

### How should this be tested?

Automated tests are preferred, but not always doable - especially for infrastructure.
Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples)

### Is there a relevant Issue open for this?

No

### Other Relevant info, PRs, etc

None
