### PR TITLE
Added postinstallation validation option

### DIFF
--- a/roles/aap_setup_install/README.md
+++ b/roles/aap_setup_install/README.md
@@ -19,6 +19,7 @@ The following input variables are available:
 |`controller_hostname/username/password/validate_certs`|none|see below|hostname and credentials of the installed controller, necessary to test previous installation|see the 'redhat\_cop.controller\_configuration' collection|
 |`ah_hostname/username/password/validate_certs`|none|see below|hostname and credentials of the installed automation hub, necessary to test previous installation|see the 'redhat\_cop.ah\_configuration' collection|
 |`aap_setup_inst_force`|false|no|a boolean deciding if the installation should proceed even if the controller and the automation hub are already installed|see [defaults/main.yml](defaults/main.yml)|
+|`aap_postinstall_validation`|`true`|no|Determines whether to perform validation against controller or automation hub after install|`false`|
 
 Note that the `controller_` and `ah_` variables are only required if the variable `aap_setup_inst_force` is _not_ true _and_ if the respective service is due to be installed.
 

--- a/roles/aap_setup_install/defaults/main.yml
+++ b/roles/aap_setup_install/defaults/main.yml
@@ -66,4 +66,7 @@ aap_setup_inst_force: false
 # review before bumping up the default AAP version
 aap_setup_inst_fixes:
   - aap_4555  # setup.log is only saved on first call as non-root (2.2.0)
+
+# perform postinstallation validation
+aap_postinstall_validation: true
 ...

--- a/roles/aap_setup_install/tasks/main.yml
+++ b/roles/aap_setup_install/tasks/main.yml
@@ -48,7 +48,7 @@
       # these will always run and will always report “changed” otherwise
 
     - name: wait for automation controller to be running
-      ansible.builtin.uri:  # use the first host from the list if no hostname is defined
+      ansible.builtin.uri: # use the first host from the list if no hostname is defined
         url: "https://{{ controller_hostname }}/"
         method: GET
         user: admin
@@ -60,10 +60,10 @@
       until: __aap_setup_inst_result.status == 200
       retries: 90
       delay: 10
-      when: "'automationcontroller' in aap_setup_prep_inv_nodes"
+      when: "'automationcontroller' in aap_setup_prep_inv_nodes and aap_postinstall_validation|bool == true"
 
     - name: wait for automation hub to be running
-      ansible.builtin.uri:  # use the first host from the list if no hostname is defined
+      ansible.builtin.uri: # use the first host from the list if no hostname is defined
         url: "https://{{ ah_hostname }}/api/galaxy/"
         method: GET
         user: admin
@@ -75,7 +75,7 @@
       until: __aap_setup_inst_result_ah.status == 200
       retries: 90
       delay: 10
-      when: "'automationhub' in aap_setup_prep_inv_nodes"
+      when: "'automationhub' in aap_setup_prep_inv_nodes and aap_postinstall_validation|bool == true"
   when: >
     aap_setup_inst_force
     or ('automationcontroller' in aap_setup_prep_inv_nodes


### PR DESCRIPTION
### What does this PR do?

Adds the capability for validations after AAP install to be skipped

### How should this be tested?

set the variable `aap_postinstall_validation=false` to ensure the functionality is realized. Not specifying this value or setting `aap_postinstall_validation=true` should enforce existing validation

### Is there a relevant Issue open for this?

None

### Other Relevant info, PRs, etc

Please provide link to other PRs that may be related (blocking, resolves, etc. etc.)
