### PR TITLE
enforce the version as string so user doesn't need to

### DIFF
--- a/roles/aap_setup_download/README.md
+++ b/roles/aap_setup_download/README.md
@@ -15,7 +15,7 @@ The following input variables are required:
 
 * `aap_setup_down_offline_token` contains your offline token as described in the requirements.
 It has no default value and _must_ be defined.
-* `aap_setup_down_version` defines the minor version to download (e.g. `2.1`), make sure you defines it as string and not as float!
+* `aap_setup_down_version` defines the minor version to download (e.g. `2.1`)
 The default is the latest version available at time of writing.
 * `aap_setup_down_dest_dir` is the directory to where you want to download the tarball.
 It is by default the working directory `aap_setup_working_dir` also used by other roles of the collection, or ultimately `/var/tmp`.

--- a/roles/aap_setup_download/tasks/main.yml
+++ b/roles/aap_setup_download/tasks/main.yml
@@ -32,7 +32,7 @@
     headers:
       Authorization: "Bearer {{ __aap_setup_down_login.json.access_token }}"
   loop: "{{ __aap_setup_down_images[:2] }}"
-  when: (aap_setup_down_type + '-' + aap_setup_down_version) in item.filename
+  when: (aap_setup_down_type + '-' + (aap_setup_down_version | string)) in item.filename
   register: __aap_setup_down_downloads
 
 - name: Extract the name of the downloaded installer to aap_setup_down_installer_file


### PR DESCRIPTION
### What does this PR do?
should remove the version being a string requirement

### How should this be tested?
test with version being a string or number and make sure the collection still functions as expected

### Is there a relevant Issue open for this?
no

### Other Relevant info, PRs, etc
none