### PR TITLE
Align linting configurations with other repos

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -10,17 +10,4 @@ use_default_rules: true
 #  with verbosity set to 1, its dumping 'unknown file type messages'
 # verbosity: 1
 skip_list: []
-# Disabled the the below skip_list as they use the old style rule names.
-# With the move of the .yamllint.yml to TLD ansible-lint now picks up our config so no need to exclude it.
-#   # [E204]: "Lines should be no longer than 160 chars"
-#   # (Disabled in June 2020)
-#   - '204'
-#   # [E106]: "Role name {} does not match ^[a-z][a-z0-9_]+$ pattern" Issue with galaxy.yml file being variable based.
-#   # (Disabled in Oct 2020)
-#   - '106'
-#   # [E208]: "File permissions not mentioned. Issue created to fix"
-#   # (Disabled in Oct 2020)
-#   # - '208'
-#   # YAML: Ansible lint doing yaml checks that we were already doing but without config.
-#   - yaml
 ...

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,5 +1,5 @@
 # This workflow action will run pre-commit, which will execute ansible and yaml linting
-# See .github/workflow-config/.pre-commit-config.yml for what hooks are executed
+# See .pre-commit-config.yml for what hooks are executed
 name: Yaml and Ansible Lint
 
 on: [push, pull_request]
@@ -13,7 +13,6 @@ jobs:
     - name: Install Collections
       run: |
         sudo apt install software-properties-common
-        sudo apt-add-repository --yes --update ppa:ansible/ansible
-        sudo apt install ansible
+        pip install --upgrade ansible
     - uses: pre-commit/action@v2.0.0
 ...

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -14,4 +14,8 @@ MD013: false
 # This will ensure that code block format is consistent across all markdown files
 MD0046:
   style: fenced
+
+MD033:
+  allowed_elements:
+    - "br"
 ...

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
   #       entry: "yamllint"
   #       types: [yaml]
   - repo: https://github.com/ansible/ansible-lint.git
-    rev: v6.5.2
+    rev: v6.6.1
     hooks:
       # see discussions here about what arguments are used, and behavior
       # https://github.com/ansible/ansible-lint/issues/649
@@ -23,6 +23,8 @@ repos:
         pass_filenames: false
         always_run: true
         entry: "ansible-lint"
+        args:
+          - "--profile=production"
   - repo: https://github.com/DavidAnson/markdownlint-cli2
     rev: v0.5.1
     hooks:

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -7,13 +7,14 @@ rules:
   colons: disable
   indentation:
     level: warning
-    indent-sequences: consistent
+    # Require indentation https://redhat-cop.github.io/automation-good-practices/#_yaml_and_jinja2_syntax
+    indent-sequences: true
   truthy:
+    level: error
+    # Allow only YAML 1.2 booleans https://redhat-cop.github.io/automation-good-practices/#_yaml_and_jinja2_syntax
     allowed-values:
-    - 'True'
-    - 'False'
-    - 'true'
-    - 'false'
+      - 'true'
+      - 'false'
   # Enabling yamllint check based on PR #35
   document-end: enable
 ...

--- a/roles/aap_certs/tasks/autohub.yml
+++ b/roles/aap_certs/tasks/autohub.yml
@@ -1,27 +1,37 @@
 ---
-
 # according to https://access.redhat.com/solutions/5731261
-- name: Autohub | copy cert into place
+
+- name: Autohub | get certificate file content
+  when:
+    - aap_certs_autohub_ssl_cert is defined
+    - aap_certs_autohub_ssl_key is defined
+  ansible.builtin.set_fact:
+    aap_certs_autohub_ssl_cert_content: "{{ lookup('ansible.builtin.file', aap_certs_autohub_ssl_cert) }}"
+    aap_certs_autohub_ssl_key_content: "{{ lookup('ansible.builtin.file', aap_certs_autohub_ssl_key) }}"
+
+- name: Autohub | update certificate file
   become: true
-  ansible.builtin.copy:
-    src: "{{ aap_certs_autohub_ssl_cert | default(omit) }}"
-    content: "{{ aap_certs_autohub_ssl_cert_content | default(omit) }}"
+  ansible.builtin.template:
+    src: cert_content.j2
     dest: "{{ aap_certs_autohub_cert_dest }}"
-    mode: u=rw,go=r
+    mode: u=rw,go=
     owner: root
     group: pulp
     backup: "{{ aap_certs_create_backup }}"
   notify: restart_aap_service
+  vars:
+    file_content: "{{ aap_certs_autohub_ssl_cert_content }}"
 
-- name: Autohub | copy key into place
+- name: Autohub | update certificate key file
   become: true
-  ansible.builtin.copy:
-    src: "{{ aap_certs_autohub_ssl_key | default(omit) }}"
-    content: "{{ aap_certs_autohub_ssl_key_content | default(omit) }}"
+  ansible.builtin.template:
+    src: cert_content.j2
     dest: "{{ aap_certs_autohub_key_dest }}"
     mode: u=rw,go=
     owner: root
     group: pulp
     backup: "{{ aap_certs_create_backup }}"
   notify: restart_aap_service
+  vars:
+    file_content: "{{ aap_certs_autohub_ssl_key_content }}"
 ...

--- a/roles/aap_certs/tasks/controller.yml
+++ b/roles/aap_certs/tasks/controller.yml
@@ -1,26 +1,37 @@
 ---
 # according to https://access.redhat.com/solutions/3109871
-- name: Controller | copy cert into place
+
+- name: Controller | get certificate file content
+  when:
+    - aap_certs_controller_ssl_cert is defined
+    - aap_certs_controller_ssl_key is defined
+  ansible.builtin.set_fact:
+    aap_certs_controller_ssl_cert_content: "{{ lookup('ansible.builtin.file', aap_certs_controller_ssl_cert) }}"
+    aap_certs_controller_ssl_key_content: "{{ lookup('ansible.builtin.file', aap_certs_controller_ssl_key) }}"
+
+- name: Controller | update certificate file
   become: true
-  ansible.builtin.copy:
-    src: "{{ aap_certs_controller_ssl_cert | default(omit) }}"
-    content: "{{ aap_certs_controller_ssl_cert_content | default(omit) }}"
+  ansible.builtin.template:
+    src: cert_content.j2
     dest: "{{ aap_certs_controller_cert_dest }}"
     mode: u=rw,go=
     owner: root
     group: awx
     backup: "{{ aap_certs_create_backup }}"
   notify: restart_aap_service
+  vars:
+    file_content: "{{ aap_certs_controller_ssl_cert_content }}"
 
-- name: Controller | copy key into place
+- name: Controller | update certificate key file
   become: true
-  ansible.builtin.copy:
-    src: "{{ aap_certs_controller_ssl_key | default(omit) }}"
-    content: "{{ aap_certs_controller_ssl_key_content | default(omit) }}"
+  ansible.builtin.template:
+    src: cert_content.j2
     dest: "{{ aap_certs_controller_key_dest }}"
     mode: u=rw,go=
     owner: root
     group: awx
     backup: "{{ aap_certs_create_backup }}"
   notify: restart_aap_service
+  vars:
+    file_content: "{{ aap_certs_controller_ssl_key_content }}"
 ...

--- a/roles/aap_certs/templates/cert_content.j2
+++ b/roles/aap_certs/templates/cert_content.j2
@@ -1,0 +1,1 @@
+{{ file_content }}

--- a/roles/aap_ocp_install/tasks/initialization.yml
+++ b/roles/aap_ocp_install/tasks/initialization.yml
@@ -8,7 +8,8 @@
   register: __aap_ocp_install_auth_results
 
 - name: Create namespace
-  kubernetes.core.k8s:
+  # Disabled the ansible-lint jinja[invalid] check as it is throwing an error due to the ways the vars are specified
+  kubernetes.core.k8s:  # noqa jinja[invalid]
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
     validate_certs: "{{ aap_ocp_install_ocp_connection['validate_certs'] | default(omit) }}"

--- a/roles/aap_ocp_install/tasks/install-controller.yml
+++ b/roles/aap_ocp_install/tasks/install-controller.yml
@@ -1,6 +1,7 @@
 ---
 - name: Create controller namespace
-  kubernetes.core.k8s:
+  # Disabled the ansible-lint jinja[invalid] check as it is throwing an error due to the ways the vars are specified
+  kubernetes.core.k8s:  # noqa jinja[invalid]
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
     validate_certs: "{{ aap_ocp_install_ocp_connection['validate_certs'] | default(omit) }}"

--- a/roles/git_ssh_setup/tests/test.yml
+++ b/roles/git_ssh_setup/tests/test.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: localhost
+- name: Test Git SSH setup
+  hosts: localhost
   remote_user: ansible
   roles:
     - git_ssh_setup


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
### What does this PR do?

This is a small linting update to align the aap_utilities linting with the other redhat_cop AAP related repos and fix any new linting errors.

### How should this be tested?

Automated tests are preferred, but not always doable - especially for infrastructure.
Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples)

### Is there a relevant Issue open for this?

No

### Other Relevant info, PRs, etc

None