### PR TITLE
silence the warning of using command instead of module

### DIFF
--- a/roles/aap_setup_prepare/tasks/main.yml
+++ b/roles/aap_setup_prepare/tasks/main.yml
@@ -8,6 +8,7 @@
   ignore_errors: true
   changed_when: false
   check_mode: false  # run this command even in check mode
+  warn: false # the query is not supported in the yum module - hence `builtin.command`
 
 - name: Install absolutely necessary packages
   ansible.builtin.yum:


### PR DESCRIPTION

<!-- markdownlint-disable MD041 -->
### What does this PR do?

This change should silence the warning of using a builtin.command instead of a module for the rpm-query.

The command is neccessary, because the module doesn't support the query atm, resulting in a warning:
```
TASK [redhat_cop.aap_utilities.aap_setup_prepare : check if the absolutely necessary packages are installed] ***********
[WARNING]: Consider using the yum, dnf or zypper module rather than running 'rpm'.  If you need to use command because
yum, dnf or zypper is insufficient you can add 'warn: false' to this command task or set 'command_warnings=False' in
ansible.cfg to get rid of this message.
```

This warning irritates users of the role, so it should be silenced

### How should this be tested?

simply run the established automated tests 

### Is there a relevant Issue open for this?

don't know

### Other Relevant info, PRs, etc

This warning just bugged my users and I wanted to help it get away...
