### PR TITLE
Fix issues with copy and /dev/null

### DIFF
--- a/roles/aap_setup_install/tasks/fixes/aap_4555.yml
+++ b/roles/aap_setup_install/tasks/fixes/aap_4555.yml
@@ -9,7 +9,7 @@
 
 - name: AAP_4555 | create a backup of setup.log if it exists
   ansible.builtin.copy:
-    src: /dev/null
+    content: ""
     dest: "{{ aap_setup_inst_setup_dir }}/setup.log"
     backup: true  # we use the backup feature of copy to save setup.log
     remote_src: true


### PR DESCRIPTION
### What does this PR do?

ansible.builtin.copy doesn't properly handle /dev/null as source, it removes it if called as root. See https://github.com/ansible/ansible/issues/79101 for details

### How should this be tested?

Run or better re-run aap_setup_install

### Is there a relevant Issue open for this?

n/a

### Other Relevant info, PRs, etc

https://github.com/ansible/ansible/issues/79101
