### PR TITLE
Convert aap_setup_down_type to string otherwise ansible complains abo…

### DIFF
--- a/roles/aap_setup_download/tasks/main.yml
+++ b/roles/aap_setup_download/tasks/main.yml
@@ -32,7 +32,7 @@
     headers:
       Authorization: "Bearer {{ __aap_setup_down_login.json.access_token }}"
   loop: "{{ __aap_setup_down_images[:2] }}"
-  when: (aap_setup_down_type + '-' + (aap_setup_down_version | string)) in item.filename
+  when: ((aap_setup_down_type | string) + '-' + (aap_setup_down_version | string)) in item.filename
   register: __aap_setup_down_downloads
 
 - name: Extract the name of the downloaded installer to aap_setup_down_installer_file


### PR DESCRIPTION
Convert aap_setup_down_type to string otherwise ansible complains about concatenating floats

<!-- markdownlint-disable MD041 -->
### What does this PR do?

Brief explanation of the code or documentation change you've made

### How should this be tested?

Automated tests are preferred, but not always doable - especially for infrastructure.
Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples)

### Is there a relevant Issue open for this?

Provide a link to any open issues that describe the problem you are solving.
resolves #[number]

### Other Relevant info, PRs, etc

Please provide link to other PRs that may be related (blocking, resolves, etc. etc.)
