### PR TITLE
remove references to Tower and change occurances of redhat_cop to infra

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -17,7 +17,7 @@ If you feel like getting your hands dirty, feel free to make the change yourself
 5. Push your code change up to your forked repo.
 6. Open a Pull Request to merge your changes to this repo. The comment box will be filled in automatically via a template.
 7. All Pull Requests will be subject to Ansible and Yaml Linting checks. Please make sure that your code complies and fix any warnings that arise. These are Checks that appear at the bottom of your Pull Request.
-8. All Pull requests are subject to Testing against being used in tower. As above there is a check at the bottom of your pull request for this named integration.
+8. All Pull requests are subject to Testing against being used against AAP. As above there is a check at the bottom of your pull request for this named integration.
 
 See [Using Pull Requests](https://help.github.com/articles/using-pull-requests/) got more information on how to use GitHub PRs.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,5 @@
 ======================================
-Redhat_Cop.Aap_Utilities Release Notes
+infra.aap_Utilities Release Notes
 ======================================
 
 .. contents:: Topics

--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ The `aap_install_ocp` role requires the `kubernetes` (version 12.0.0 or later) P
 
 |Collection Name|Purpose|
 |:---:|:---:|
-|[Controller Configuration](https://galaxy.ansible.com/redhat_cop/controller_configuration)|Automation controller configuration|
-|[Hub Configuration](https://galaxy.ansible.com/redhat_cop/ah_configuration)|Automation hub configuration|
-|[EE Utilities](https://galaxy.ansible.com/redhat_cop/ee_utilities)|Execution Environment creation utilities|
-|[AAP installation Utilities](https://galaxy.ansible.com/redhat_cop/aap_utilities)|Ansible Automation Platform Utilities|
+|[Controller Configuration](https://galaxy.ansible.com/infra/controller_configuration)|Automation controller configuration|
+|[Hub Configuration](https://galaxy.ansible.com/infra/ah_configuration)|Automation hub configuration|
+|[EE Utilities](https://galaxy.ansible.com/infra/ee_utilities)|Execution Environment creation utilities|
+|[AAP installation Utilities](https://galaxy.ansible.com/infra/aap_utilities)|Ansible Automation Platform Utilities|
 |[AAP Configuration Template](https://github.com/redhat-cop/aap_configuration_template)|Configuration Template for this suite|
 
 ## Included content
@@ -50,7 +50,7 @@ Click the `Content` button to see the list of content included in this collectio
 You can install the redhat\_cop aap\_utilities collection with the Ansible Galaxy CLI:
 
 ```bash
-ansible-galaxy collection install redhat_cop.aap_utilities
+ansible-galaxy collection install infra.aap_utilities
 ```
 
 You can also include it in a `requirements.yml` file and install it with `ansible-galaxy collection install -r requirements.yml`, using the format:
@@ -58,7 +58,7 @@ You can also include it in a `requirements.yml` file and install it with `ansibl
 ```yaml
 ---
 collections:
-  - name: redhat_cop.aap_utilities
+  - name: infra.aap_utilities
     # If you need a specific version of the collection, you can specify like this:
     # version: ...
 ```

--- a/changelogs/config.yaml
+++ b/changelogs/config.yaml
@@ -28,7 +28,7 @@ sections:
     - Bugfixes
   - - known_issues
     - Known Issues
-title: Redhat_Cop.Aap_Utilities
+title: infra.aap_Utilities
 trivial_section_name: trivial
 use_fqcn: true
 ...

--- a/roles/aap_backup/README.md
+++ b/roles/aap_backup/README.md
@@ -1,6 +1,6 @@
-# redhat\_cop.aap\_utilities.backup
+# infra.aap\_utilities.backup
 
-Ansible role to backup Ansible Tower.
+Ansible role to backup Ansible Automation Platform.
 
 ## Requirements
 
@@ -11,90 +11,8 @@ None
 Available variables are listed below, along with default values defined (see defaults/main.yml)
 
 ```yaml
-aap_setup_working_dir: "/root/"
-backup_dest: "{{ aap_setup_working_dir }}/"
-
-# Use the default tower installation template
-pre_tasks_process_template: true
-
-# Tower variables
-tower_admin_password: "password"
-
-# Postgresql variables
-tower_pg_database: "awx"
-tower_pg_username: "awx"
-tower_pg_password: "password"
-
-# RabbitMQ variables (Tower<=3.6)
-tower_rabbitmq_username: tower
-tower_rabbitmq_password: "password"
-tower_rabbitmq_cookie: "cookiemonster"
-tower_rabbitmq_port: 5672
-tower_rabbitmq_vhost: tower
-tower_rabbitmq_use_long_name: false
-
-tower_releases_url: https://releases.ansible.com/ansible-tower/setup
-tower_setup_file: ansible-tower-setup-{{ tower_release_version }}.tar.gz
-
-tower_nodes:
-  - "localhost ansible_connection=local"
-
-tower_database_node: ""
-tower_database_port: ""
-
-tower_ssh_connection_vars: ''
-
-# as long as the host name is empty, Automation Hub will NOT be installed
-tower_ah_nodes: []
-
-# the default configures an AH using the default database with similar defaults
-# as Tower
-tower_ah_admin_password: "{{ tower_admin_password }}"
-# if tower_database_node isn't defined or is empty,
-# the host where the installation takes place is deemed to host the DB
-tower_ah_pg_node: "{{ tower_database_node | default(ansible_host | default(inventory_hostname), true) }}"
-tower_ah_pg_port: "{{ tower_database_port }}"
-tower_ah_pg_database: 'automationhub'  # it is NOT supported to use the same name as for Tower!
-tower_ah_pg_username: "{{ tower_pg_username }}"
-tower_ah_pg_password: "{{ tower_pg_password }}"
-tower_ah_pg_sslmode: prefer
-
-# The below variables are unset, but can be used to affect certificates within the automation platform
-tower_ah_ssl_cert: <unset>
-tower_ah_ssl_key: <unset>
-tower_ssl_cert: <unset>
-tower_ssl_key: <unset>
-tower_pg_ssl_cert: <unset>
-tower_pg_ssl_key: <unset>
-tower_custom_ca_cert: <unset>
-
-# Set isolated groups for isolated nodes if required (commented out, an example setting)
-isolated_groups: <unset>
-  # - name: dmz1
-  #   hostnames:
-  #   - isolatednode0.dmz1.example.com
-  # - name: dmz2
-  #   hostnames:
-  #   - isolatednode0.dmz2.example.com
-  #   - isolatednode1.dmz2.example.com
-```
-
-## tower_ssh_connection_vars
-
-connection vars can be set in the inventory file through a list of vars
-
-```yaml
-tower_ssh_connection_vars:
-  - name: ansible_connection
-    value: ssh
-  - name: ansible_user
-    value: vagrant
-  - name: ansible_ssh_pass
-    value: vagrant
-  - name: ansible_ssh_private_key_file
-    value: /path/to/file
-  - name: ansible_become
-    value: true
+aap_setup_working_dir:  # Must be set, though if the aap_setup_prepare role has been run prior, a fact will be set.
+aap_backup_dest: "/root"
 ```
 
 ## Example Playbook
@@ -102,7 +20,7 @@ tower_ssh_connection_vars:
 The following playbook and accompanying vars file containing the defined seed objects can be invoked in the following manner.
 
 ```sh
-ansible-playbook playbook.yml -e @controller_vars.yml controller
+ansible-playbook playbook.yml -e @aap_vars.yml controller
 ```
 
 ```yaml
@@ -113,12 +31,10 @@ ansible-playbook playbook.yml -e @controller_vars.yml controller
   hosts: localhost
   become: true
   vars:
-    tower_nodes:
-      - "clusternode[1:3].example.com"
-    tower_database_node: "dbnode.example.com"
-    tower_working_location: "{{playbook_dir}}"
+    aap_setup_working_dir: /root/ansible-automation-platform-installer/
+    aap_backup_dest: /aap_backups/
   roles:
-    - redhat_cop.aap_utilities.aap_backup
+    - infra.aap_utilities.aap_backup
 ```
 
 ## License

--- a/roles/aap_certs/README.md
+++ b/roles/aap_certs/README.md
@@ -1,4 +1,4 @@
-# redhat\_cop.tower\_utilities.aap\_certs
+# infra.aap\_utilities.aap\_certs
 
 Ansible role to install SSL certificates for AAP automation controller and/or automation hub.
 
@@ -48,13 +48,11 @@ aap_certs_create_backup: false
 The following playbook and accompanying vars file containing the defined seed objects can be invoked in the following manner.
 
 ```sh
-ansible-playbook playbook.yml -e @tower_vars.yml tower
+ansible-playbook playbook.yml -e @aap_vars.yml
 ```
 
 ```yaml
 ---
-# Playbook to install Ansible Tower as a single node
-
 - name: Install AAP certificates
   hosts: aap_servers
   become: true
@@ -64,7 +62,7 @@ ansible-playbook playbook.yml -e @tower_vars.yml tower
     aap_certs_autohub_ssl_cert: ""
     aap_certs_autohub_ssl_key: ""
   roles:
-    - ansible-tower-install
+    - infra.aap_utilities.aap_certs
 ```
 
 ## License

--- a/roles/aap_ocp_install/README.md
+++ b/roles/aap_ocp_install/README.md
@@ -1,4 +1,4 @@
-# aap_ocp_install
+# infra.aap_utilities.aap_ocp_install
 
 A role to install Ansible Automation Platform (AAP) 2.x on OpenShift using the operator.
 
@@ -93,7 +93,7 @@ Including an example of how to use your role (for instance, with variables passe
       instance_name: automationhub
 
   roles:
-    - redhat_cop.aap_utilities.aap_ocp_install
+    - infra.aap_utilities.aap_ocp_install
 ...
 ```
 

--- a/roles/aap_remove/README.md
+++ b/roles/aap_remove/README.md
@@ -1,4 +1,4 @@
-# redhat_cop.aap_utilities.aap_remove
+# infra.aap_utilities.aap_remove
 
 Ansible role to remove instances of AAP.
 
@@ -31,14 +31,14 @@ An example is below.
   vars:
     aap_remove_controller: true
   roles:
-    - redhat_cop.aap_utilities.aap_remove
+    - infra.aap_utilities.aap_remove
 
 - name: Remove Ansible Automation Hub
   hosts: ah
   vars:
     aap_remove_ah: true
   roles:
-    - redhat_cop.aap_utilities.aap_remove
+    - infra.aap_utilities.aap_remove
 ```
 
 ## License

--- a/roles/aap_remove/defaults/main.yml
+++ b/roles/aap_remove/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-# defaults file for redhat_cop.aap_utilities.aap_remove
+# defaults file for infra.aap_utilities.aap_remove
 
 ############################################################
 #               AAP Remove Vars                         #

--- a/roles/aap_restore/README.md
+++ b/roles/aap_restore/README.md
@@ -1,6 +1,6 @@
-# redhat\_cop.aap\_utilities.aap\_restore
+# infra.aap\_utilities.aap\_restore
 
-Ansible role to restore a backup of Ansible Tower.
+Ansible role to restore a backup of Ansible Automation Platform.
 
 ## Requirements
 
@@ -12,73 +12,8 @@ Available variables are listed below, along with default values defined (see def
 
 ```yaml
 # Role Vars
-aap_setup_working_dir: "/root/"
-aap_restore_file: "automation-platform-backup-latest.tar.gz"
-aap_restore_location: "{{ aap_setup_working_dir }}/{{ restore_file }}"
-
-# Use the default tower installation template
-pre_tasks_process_template: true
-
-# Tower variables
-tower_admin_password: "password"
-
-# Postgresql variables
-tower_pg_database: "awx"
-tower_pg_username: "awx"
-tower_pg_password: "password"
-
-# RabbitMQ variables (Tower<=3.6)
-tower_rabbitmq_username: tower
-tower_rabbitmq_password: "password"
-tower_rabbitmq_cookie: "cookiemonster"
-tower_rabbitmq_port: 5672
-tower_rabbitmq_vhost: tower
-tower_rabbitmq_use_long_name: false
-
-tower_releases_url: https://releases.ansible.com/ansible-tower/setup
-tower_setup_file: ansible-tower-setup-{{ tower_release_version }}.tar.gz
-
-tower_nodes:
-  - "localhost ansible_connection=local"
-
-tower_database_node: ""
-tower_database_port: ""
-
-tower_ssh_connection_vars: ''
-
-# as long as the host name is empty, Automation Hub will NOT be installed
-tower_ah_nodes: []
-
-# the default configures an AH using the default database with similar defaults
-# as Tower
-tower_ah_admin_password: "{{ tower_admin_password }}"
-# if tower_database_node isn't defined or is empty,
-# the host where the installation takes place is deemed to host the DB
-tower_ah_pg_node: "{{ tower_database_node | default(ansible_host | default(inventory_hostname), true) }}"
-tower_ah_pg_port: "{{ tower_database_port }}"
-tower_ah_pg_database: 'automationhub'  # it is NOT supported to use the same name as for Tower!
-tower_ah_pg_username: "{{ tower_pg_username }}"
-tower_ah_pg_password: "{{ tower_pg_password }}"
-tower_ah_pg_sslmode: prefer
-
-# The below variables are unset, but can be used to affect certificates within the automation platform
-tower_ah_ssl_cert: <unset>
-tower_ah_ssl_key: <unset>
-tower_ssl_cert: <unset>
-tower_ssl_key: <unset>
-tower_pg_ssl_cert: <unset>
-tower_pg_ssl_key: <unset>
-tower_custom_ca_cert: <unset>
-
-# Set isolated groups for isolated nodes if required (commented out, an example setting)
-isolated_groups: <unset>
-  # - name: dmz1
-  #   hostnames:
-  #   - isolatednode0.dmz1.example.com
-  # - name: dmz2
-  #   hostnames:
-  #   - isolatednode0.dmz2.example.com
-  #   - isolatednode1.dmz2.example.com
+aap_setup_working_dir:  # Must be set, though if the aap_setup_prepare role has been run prior, a fact will be set.
+aap_restore_location: "{{ aap_setup_working_dir }}/{{ aap_restore_file }}"
 ```
 
 ## Example Playbook
@@ -86,24 +21,19 @@ isolated_groups: <unset>
 The following playbook and accompanying vars file containing the defined seed objects can be invoked in the following manner.
 
 ```sh
-ansible-playbook playbook.yml -e @tower_vars.yml tower
+ansible-playbook playbook.yml -e @aap_vars.yml
 ```
 
 ```yaml
 ---
-# Playbook to install Ansible Tower as a cluster
-
-- name: Restore Ansible Tower
+- name: Restore AAP
   hosts: localhost
   become: true
   vars:
-    tower_nodes:
-      - "clusternode[1:3].example.com"
-    tower_database_node: "dbnode.example.com"
-    tower_working_location: "{{playbook_dir}}"
-    restore_location: "{{playbook_dir}}/tower-backup-latest.tar.gz"
+    aap_setup_working_dir: /root/ansible-automation-platform-installer/
+    aap_restore_location: "{{playbook_dir}}/aap-backup-latest.tar.gz"
   roles:
-    - redhat_cop.aap_utilities.aap_restore
+    - infra.aap_utilities.aap_restore
 ```
 
 ## License

--- a/roles/aap_restore/defaults/main.yml
+++ b/roles/aap_restore/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-# defaults file for redhat_cop.aap_utilities.aap_restore
+# defaults file for infra.aap_utilities.aap_restore
 
 ############################################################
 #               AAP Restore Vars                           #

--- a/roles/aap_setup_download/README.md
+++ b/roles/aap_setup_download/README.md
@@ -1,4 +1,4 @@
-# aap\_setup\_download
+# infra.aap_utilities.aap\_setup\_download
 
 A role to download the latest z-version of the AAP setup tarball for a given minor version (e.g. 2.1 at time of writing).
 
@@ -35,8 +35,8 @@ Combined with the role `aap_setup_prepare`, the following code will download and
 ```yaml
 - hosts: installationserver
   roles:
-    - { role: redhat_cop.aap_utilities.aap_setup_download }
-    - { role: redhat_cop.aap_utilities.aap_setup_prepare }
+    - { role: infra.aap_utilities.aap_setup_download }
+    - { role: infra.aap_utilities.aap_setup_prepare }
 ```
 
 ## License

--- a/roles/aap_setup_install/README.md
+++ b/roles/aap_setup_install/README.md
@@ -1,4 +1,4 @@
-# aap\_setup\_install
+# infra.aap_utilities.aap\_setup\_install
 
 A role to install AAP 2.x, installing pre-requisites, unpacking the installation tarball and (optionally) writing the necessary inventory file.
 
@@ -37,9 +37,9 @@ Note that the `controller_` and `ah_` variables are only required if the variabl
   become: false
   tags: aap_installation
   roles:
-    - redhat_cop.aap_utilities.aap_setup_download
-    - redhat_cop.aap_utilities.aap_setup_prepare
-    - redhat_cop.aap_utilities.aap_setup_install
+    - infra.aap_utilities.aap_setup_download
+    - infra.aap_utilities.aap_setup_prepare
+    - infra.aap_utilities.aap_setup_install
 ```
 
 Note that this only works without root access if the bastion host isn't part of the future cluster,

--- a/roles/aap_setup_prepare/README.md
+++ b/roles/aap_setup_prepare/README.md
@@ -1,4 +1,4 @@
-# aap\_setup\_prepare
+# infra.aap_utilities.aap\_setup\_prepare
 
 A role to prepare the installation of AAP 2.x, installing pre-requisites,
 unpacking the installation tarball and (optionally) writing the necessary inventory file.
@@ -40,9 +40,9 @@ By convention the [defaults/main.yml](defaults/main.yml) contains all possible v
   become: false
   tags: aap_installation
   roles:
-    - redhat_cop.aap_utilities.aap_setup_download
-    - redhat_cop.aap_utilities.aap_setup_prepare
-    - redhat_cop.aap_utilities.aap_setup_install
+    - infra.aap_utilities.aap_setup_download
+    - infra.aap_utilities.aap_setup_prepare
+    - infra.aap_utilities.aap_setup_install
 ```
 
 Note that this only works without root access if the bastion host isn't part of the future cluster,

--- a/roles/aap_setup_prepare/tasks/main.yml
+++ b/roles/aap_setup_prepare/tasks/main.yml
@@ -26,7 +26,7 @@
     exclude: "inventory"
   register: __aap_setup_prep_extract
 
-- name: Set tower_setup_dir
+- name: Set aap_setup_prep_setup_dir
   ansible.builtin.set_fact:
     aap_setup_prep_setup_dir: "{{ aap_setup_prep_working_dir }}/{{ __aap_setup_prep_extract.files[0] }}"
 

--- a/roles/git_ssh_setup/README.md
+++ b/roles/git_ssh_setup/README.md
@@ -1,7 +1,7 @@
-# redhat\_cop.aap\_utilities.git\_ssh\_setup
+# infra.aap\_utilities.git\_ssh\_setup
 
 Creates a minimal Git server which can be used over SSH. It isn't meant as a full blown Git server,
-but just for demonstration and learning purposes, and can be installed directly on the Tower server.
+but just for demonstration and learning purposes, and can be installed directly on the AAP servers.
 
 ## Requirements
 
@@ -21,12 +21,12 @@ The following snippet, using the defaults, will create two Git repos under the g
 which can be used (cloned and written) by the Ansible user:
 
 ```yaml
-- hosts: tower.example.com
+- hosts: controller.example.com
   roles:
-    - git_ssh_setup
+    - infra.aap_utilities.git_ssh_setup
 ```
 
-We've assumed that it will be created directly on the Tower server for demonstration purposes.
+We've assumed that it will be created directly on the Controller server for demonstration purposes.
 
 ## License
 
@@ -34,4 +34,4 @@ We've assumed that it will be created directly on the Tower server for demonstra
 
 ## Author Information
 
-Create an [issue at GitHub](https://github.com/redhat-cop/tower_utilities/issues) if you want to contact us.
+Create an [issue at GitHub](https://github.com/redhat-cop/aap_utilities/issues) if you want to contact us.

--- a/roles/kerberos/README.md
+++ b/roles/kerberos/README.md
@@ -1,4 +1,4 @@
-# redhat\_cop.aap\_utilities.kerberos
+# infra.aap\_utilities.kerberos
 
 ## Description
 
@@ -73,14 +73,14 @@ ensure that you have set them either on the server running the playbook, or in t
 
 ```yaml
 ---
-- hosts: towers
+- hosts: controllers
 # If you need proxy settings to install packages from the internet:
 # The following 3 lines are optional
   environment:
     http_proxy: "yourproxyurl:andport"
     https_proxy: "yourproxyurl:andport"
   roles:
-    - role: redhat_cop.aap_utilities.kerberos
+    - role: infra.aap_utilities.kerberos
       krb_default_realm: MYDOMAIN.COM
       krb_realms:
         - name: "MYDOMAIN.COM"

--- a/roles/kerberos/meta/main.yml
+++ b/roles/kerberos/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 galaxy_info:
   author: "Andrew J. Huffman"
-  description: "An Ansible role to configure Ansible Tower nodes to manage Windows systems."
+  description: "An Ansible role to configure Ansible Controller nodes to manage Windows systems."
   company: "Red Hat"
 
   # If the issue tracker for your role is not on github, uncomment the
@@ -149,8 +149,8 @@ galaxy_info:
         #   - any
 
   galaxy_tags:
-    - "ansibletower"
-    - "tower"
+    - "ansiblecontroller"
+    - "controller"
     - "awx"
     - "configuration"
     - "system"


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

I started this removing any old Tower references but then also made changes for redhat_cop -> infra namespace

# How should this be tested?

Readme changes which CI will lint

# Is there a relevant Issue open for this?

resolves #99 
Though only some of the additional comments. The original aim of the issue probably isn't required to be addressed.

# Other Relevant info, PRs, etc
N/A
