### PR TITLE
Add meta-unsupported-ansible to skip-list of ansible lint

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -9,5 +9,6 @@ use_default_rules: true
 # https://github.com/ansible/ansible-lint/issues/808
 #  with verbosity set to 1, its dumping 'unknown file type messages'
 # verbosity: 1
-skip_list: []
+skip_list:
+  - meta-unsupported-ansible
 ...


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

Fixes broken CI Ansible-lint where meta-unsupported-ansible is presumably a new rule which we don't match but we don't need to change out minimum supported Ansible so we should just skip this rule.

# How should this be tested?
CI will pass

# Is there a relevant Issue open for this?
N/A

# Other Relevant info, PRs, etc
See failing CI here: https://github.com/redhat-cop/aap_utilities/actions/runs/3955727871/jobs/6774258851

