### PR TITLE
Added example inventory vars to readmes for install and prepare roles

### DIFF
--- a/roles/aap_setup_install/README.md
+++ b/roles/aap_setup_install/README.md
@@ -54,13 +54,13 @@ aap_setup_down_type: "setup-bundle"
 aap_setup_rhel_version: 8
 
 aap_setup_prep_inv_nodes:
-  automationcontroller: 
+  automationcontroller:
     - ansible-ctrl.example.com
-  automationhub: 
+  automationhub:
     - ansible-hub.example.com
-  database: 
+  database:
     - database.example # if using an already existing DB, remove this and ensure that the following variables are filled with the valid details for your Controller and PAH
-                       # databases: pg_host, pg_port, pg_database, ph_username, pg_password, automationhub_pg_host, automationhub_pg_port, automationhub_pg_database, 
+                       # databases: pg_host, pg_port, pg_database, ph_username, pg_password, automationhub_pg_host, automationhub_pg_port, automationhub_pg_database,
                        # automationhub_pg_username, automationhub_pg_password, automationhub_pg_sslmode
   execution_nodes:
     - execution-1.example
@@ -70,9 +70,9 @@ aap_setup_prep_inv_nodes:
 
 aap_setup_prep_inv_vars:
   automationcontroller: # denotes the automation controller nodes as hybrid nodes (both controller and execution)
-    peers: execution_nodes 
-    node_type: hybrid 
-    
+    peers: execution_nodes
+    node_type: hybrid
+
   execution_nodes:
     node_type: execution
 
@@ -100,7 +100,7 @@ aap_setup_prep_inv_vars:
     automationhub_pg_password: changeme
     automationhub_pg_sslmode: 'prefer'
     automationhub_main_url: hub.example
-    automationhub_require_content_approval: False 
+    automationhub_require_content_approval: False
     automationhub_enable_unauthenticated_collection_access: True
 
     automationhub_ssl_validate_certs: False
@@ -108,7 +108,7 @@ aap_setup_prep_inv_vars:
     sso_console_admin_password: ''
 
 aap_setup_prep_inv_secrets:
-  all: 
+  all:
     registry_username: changeme
     registry_password: changeme
 ```

--- a/roles/aap_setup_install/README.md
+++ b/roles/aap_setup_install/README.md
@@ -46,6 +46,73 @@ Note that this only works without root access if the bastion host isn't part of 
 and if the RPM pre-requisites have been pre-installed.
 Else change to `become: true`.
 
+## Example Inventory Variables
+
+```yaml
+---
+aap_setup_down_type: "setup-bundle"
+aap_setup_rhel_version: 8
+
+aap_setup_prep_inv_nodes:
+  automationcontroller: 
+    - ansible-ctrl.example.com
+  automationhub: 
+    - ansible-hub.example.com
+  database: 
+    - database.example # if using an already existing DB, remove this and ensure that the following variables are filled with the valid details for your Controller and PAH
+                       # databases: pg_host, pg_port, pg_database, ph_username, pg_password, automationhub_pg_host, automationhub_pg_port, automationhub_pg_database, 
+                       # automationhub_pg_username, automationhub_pg_password, automationhub_pg_sslmode
+  execution_nodes:
+    - execution-1.example
+    - execution-2.example
+  #servicescatalog_workers:
+  #sso:
+
+aap_setup_prep_inv_vars:
+  automationcontroller: # denotes the automation controller nodes as hybrid nodes (both controller and execution)
+    peers: execution_nodes 
+    node_type: hybrid 
+    
+  execution_nodes:
+    node_type: execution
+
+  all:
+    ansible_user: ansible
+    ansible_become: true
+    admin_password: changeme # admin password for Automation Controller UI
+    pg_host: 'database.example'
+    pg_port: '5432'
+
+    pg_database: 'awx'
+    pg_username: 'awx'
+    pg_password: changeme
+    pg_sslmode: 'prefer'  # set to 'verify-full' for client-side enforced SSL
+
+    registry_url: 'registry.redhat.io'
+    receptor_listener_port: 27199
+
+    automationhub_admin_password: changeme # admin password for PAH UI
+    automationhub_pg_host: 'database.example'
+    automationhub_pg_port: '5432'
+
+    automationhub_pg_database: 'automationhub'
+    automationhub_pg_username: 'automationhub'
+    automationhub_pg_password: changeme
+    automationhub_pg_sslmode: 'prefer'
+    automationhub_main_url: hub.example
+    automationhub_require_content_approval: False 
+    automationhub_enable_unauthenticated_collection_access: True
+
+    automationhub_ssl_validate_certs: False
+
+    sso_console_admin_password: ''
+
+aap_setup_prep_inv_secrets:
+  all: 
+    registry_username: changeme
+    registry_password: changeme
+```
+
 ## License
 
 [GPLv3+0](https://github.com/redhat-cop/aap_utilities#licensing)

--- a/roles/aap_setup_prepare/README.md
+++ b/roles/aap_setup_prepare/README.md
@@ -60,13 +60,13 @@ aap_setup_down_type: "setup-bundle"
 aap_setup_rhel_version: 8
 
 aap_setup_prep_inv_nodes:
-  automationcontroller: 
+  automationcontroller:
     - ansible-ctrl.example.com
-  automationhub: 
+  automationhub:
     - ansible-hub.example.com
-  database: 
+  database:
     - database.example # if using an already existing DB, remove this and ensure that the following variables are filled with the valid details for your Controller and PAH
-                       # databases: pg_host, pg_port, pg_database, ph_username, pg_password, automationhub_pg_host, automationhub_pg_port, automationhub_pg_database, 
+                       # databases: pg_host, pg_port, pg_database, ph_username, pg_password, automationhub_pg_host, automationhub_pg_port, automationhub_pg_database,
                        # automationhub_pg_username, automationhub_pg_password, automationhub_pg_sslmode
   execution_nodes:
     - execution-1.example
@@ -76,9 +76,9 @@ aap_setup_prep_inv_nodes:
 
 aap_setup_prep_inv_vars:
   automationcontroller: # denotes the automation controller nodes as hybrid nodes (controller and execution)
-    peers: execution_nodes 
-    node_type: hybrid 
-    
+    peers: execution_nodes
+    node_type: hybrid
+
   execution_nodes:
     node_type: execution
 
@@ -114,7 +114,7 @@ aap_setup_prep_inv_vars:
     sso_console_admin_password: ''
 
 aap_setup_prep_inv_secrets:
-  all: 
+  all:
     registry_username: changeme
     registry_password: changeme
 ```

--- a/roles/aap_setup_prepare/README.md
+++ b/roles/aap_setup_prepare/README.md
@@ -39,6 +39,9 @@ By convention the [defaults/main.yml](defaults/main.yml) contains all possible v
   gather_facts: false
   become: false
   tags: aap_installation
+
+  vars_files:
+    - inventory_vars/variables.yml
   roles:
     - infra.aap_utilities.aap_setup_download
     - infra.aap_utilities.aap_setup_prepare
@@ -48,6 +51,73 @@ By convention the [defaults/main.yml](defaults/main.yml) contains all possible v
 Note that this only works without root access if the bastion host isn't part of the future cluster,
 and if the RPM pre-requisites have been pre-installed.
 Else change to `become: true`.
+
+## Example Inventory Variables
+
+```yaml
+---
+aap_setup_down_type: "setup-bundle"
+aap_setup_rhel_version: 8
+
+aap_setup_prep_inv_nodes:
+  automationcontroller: 
+    - ansible-ctrl.example.com
+  automationhub: 
+    - ansible-hub.example.com
+  database: 
+    - database.example # if using an already existing DB, remove this and ensure that the following variables are filled with the valid details for your Controller and PAH
+                       # databases: pg_host, pg_port, pg_database, ph_username, pg_password, automationhub_pg_host, automationhub_pg_port, automationhub_pg_database, 
+                       # automationhub_pg_username, automationhub_pg_password, automationhub_pg_sslmode
+  execution_nodes:
+    - execution-1.example
+    - execution-2.example
+  #servicescatalog_workers:
+  #sso:
+
+aap_setup_prep_inv_vars:
+  automationcontroller: # denotes the automation controller nodes as hybrid nodes (controller and execution)
+    peers: execution_nodes 
+    node_type: hybrid 
+    
+  execution_nodes:
+    node_type: execution
+
+  all:
+    ansible_user: ansible
+    ansible_become: true
+    admin_password: changeme # admin password for Automation Controller UI
+    pg_host: 'database.example'
+    pg_port: '5432'
+
+    pg_database: 'awx'
+    pg_username: 'awx'
+    pg_password: changeme
+    pg_sslmode: 'prefer'  # set to 'verify-full' for client-side enforced SSL
+
+    registry_url: 'registry.redhat.io'
+    receptor_listener_port: 27199
+
+    automationhub_admin_password: changeme # admin password for PAH UI
+    automationhub_pg_host: 'database.example'
+    automationhub_pg_port: '5432'
+
+    automationhub_pg_database: 'automationhub'
+    automationhub_pg_username: 'automationhub'
+    automationhub_pg_password: changeme
+    automationhub_pg_sslmode: 'prefer'
+    automationhub_main_url: hub.example
+    automationhub_require_content_approval: False
+    automationhub_enable_unauthenticated_collection_access: True
+
+    automationhub_ssl_validate_certs: False
+
+    sso_console_admin_password: ''
+
+aap_setup_prep_inv_secrets:
+  all: 
+    registry_username: changeme
+    registry_password: changeme
+```
 
 ## License
 


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

Added example variables for aap_setup_prep_inv_nodes and aap_setup_prep_inv_vars to READMEs for aap_setup_prepare and aap_setup_install.

# How should this be tested?

README change, does not require testing

# Is there a relevant Issue open for this?

resolves #88 

# Other Relevant info, PRs, etc

N/A
