### PR TITLE
Skip ansible-lint rules

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -4,6 +4,9 @@
 # https://github.com/ansible/ansible-lint/issues/371
 # exclude_paths:
 #   - roles/master_role_example/
+exclude_paths:
+  - '.github/'
+  - 'changelogs/'
 parseable: true
 use_default_rules: true
 # https://github.com/ansible/ansible-lint/issues/808
@@ -11,4 +14,7 @@ use_default_rules: true
 # verbosity: 1
 skip_list:
   - meta-runtime
+warn_list:
+  - jinja[invalid]  # Temporarily adding this due to https://github.com/ansible/ansible-lint/issues/3048
+  - jinja[spacing]  # Would be set to warn by default and the only flagged issues are fairly unfixable
 ...

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -16,5 +16,4 @@ skip_list:
   - meta-runtime
 warn_list:
   - jinja[invalid]  # Temporarily adding this due to https://github.com/ansible/ansible-lint/issues/3048
-  - jinja[spacing]  # Would be set to warn by default and the only flagged issues are fairly unfixable
 ...


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Fixes lint issues caused by update to ansible-lint 6.13.0
<!--- Brief explanation of the code or documentation change you've made -->

# How should this be tested?
CI should pass
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

# Is there a relevant Issue open for this?

<!--- Provide a link to any open issues that describe the problem you are solving. -->
N/A

# Other Relevant info, PRs, etc
Note that I've set jinja[invalid] to warn for now because the new version has caused a regression in this rule which I've raised a bug for and linked to from the PR in controller_configuration https://github.com/redhat-cop/controller_configuration/pull/503
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
