### PR TITLE
handle passwords in aap_setup_prep_inv_secrets

### DIFF
--- a/changelogs/fragments/use-inv-secrets.yml
+++ b/changelogs/fragments/use-inv-secrets.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Availability checks will use credentials from either aap_setup_prep_inv_secrets or aap_setup_prep_inv_vars
+...

--- a/roles/aap_setup_install/tasks/main.yml
+++ b/roles/aap_setup_install/tasks/main.yml
@@ -11,8 +11,7 @@
     url: "https://{{ controller_hostname }}/"
     method: GET
     user: admin
-    password: "{{ aap_setup_prep_inv_secrets.all.admin_password | default(false) or
-                  aap_setup_prep_inv_vars.all.admin_password }}"
+    password: "{{ aap_setup_prep_inv_secrets.all.admin_password | default(aap_setup_prep_inv_vars.all.admin_password) }}"
     validate_certs: "{{ controller_validate_certs | default('false') }}"
     force_basic_auth: true
   register: __aap_setup_inst_ctl_check
@@ -27,8 +26,7 @@
     url: "https://{{ ah_hostname }}/api/galaxy/"
     method: GET
     user: admin
-    password: "{{ aap_setup_prep_inv_secrets.all.automationhub_admin_password | default(false) or
-                  aap_setup_prep_inv_vars.all.automationhub_admin_password }}"
+    password: "{{ aap_setup_prep_inv_secrets.all.automationhub_admin_password | default(aap_setup_prep_inv_vars.all.automationhub_admin_password) }}"
     validate_certs: "{{ controller_validate_certs | default('false') }}"
     force_basic_auth: true
   register: __aap_setup_inst_ah_check
@@ -68,8 +66,7 @@
         url: "https://{{ controller_hostname }}/"
         method: GET
         user: admin
-        password: "{{ aap_setup_prep_inv_secrets.all.admin_password | default(false) or
-                      aap_setup_prep_inv_vars.all.admin_password }}"
+        password: "{{ aap_setup_prep_inv_secrets.all.admin_password | default(aap_setup_prep_inv_vars.all.admin_password) }}"
         force_basic_auth: true
         status_code: 200
         validate_certs: "{{ controller_validate_certs | default(omit) }}"
@@ -84,8 +81,7 @@
         url: "https://{{ ah_hostname }}/api/galaxy/"
         method: GET
         user: admin
-        password: "{{ aap_setup_prep_inv_secrets.all.automationhub_admin_password | default(false) or
-                      aap_setup_prep_inv_vars.all.automationhub_admin_password }}"
+        password: "{{ aap_setup_prep_inv_secrets.all.automationhub_admin_password | default(aap_setup_prep_inv_vars.all.automationhub_admin_password) }}"
         force_basic_auth: true
         status_code: 200
         validate_certs: "{{ ah_validate_certs | default(omit) }}"

--- a/roles/aap_setup_install/tasks/main.yml
+++ b/roles/aap_setup_install/tasks/main.yml
@@ -11,7 +11,8 @@
     url: "https://{{ controller_hostname }}/"
     method: GET
     user: admin
-    password: "{{ aap_setup_prep_inv_vars.all.admin_password }}"
+    password: "{{ aap_setup_prep_inv_secrets.all.admin_password | default(false) or
+                  aap_setup_prep_inv_vars.all.admin_password }}"
     validate_certs: "{{ controller_validate_certs | default('false') }}"
     force_basic_auth: true
   register: __aap_setup_inst_ctl_check
@@ -26,7 +27,8 @@
     url: "https://{{ ah_hostname }}/api/galaxy/"
     method: GET
     user: admin
-    password: "{{ aap_setup_prep_inv_vars.all.automationhub_admin_password }}"
+    password: "{{ aap_setup_prep_inv_secrets.all.automationhub_admin_password | default(false) or
+                  aap_setup_prep_inv_vars.all.automationhub_admin_password }}"
     validate_certs: "{{ controller_validate_certs | default('false') }}"
     force_basic_auth: true
   register: __aap_setup_inst_ah_check
@@ -66,7 +68,8 @@
         url: "https://{{ controller_hostname }}/"
         method: GET
         user: admin
-        password: "{{ aap_setup_prep_inv_vars.all.admin_password }}"
+        password: "{{ aap_setup_prep_inv_secrets.all.admin_password | default(false) or
+                      aap_setup_prep_inv_vars.all.admin_password }}"
         force_basic_auth: true
         status_code: 200
         validate_certs: "{{ controller_validate_certs | default(omit) }}"
@@ -81,7 +84,8 @@
         url: "https://{{ ah_hostname }}/api/galaxy/"
         method: GET
         user: admin
-        password: "{{ aap_setup_prep_inv_vars.all.automationhub_admin_password }}"
+        password: "{{ aap_setup_prep_inv_secrets.all.automationhub_admin_password | default(false) or
+                      aap_setup_prep_inv_vars.all.automationhub_admin_password }}"
         force_basic_auth: true
         status_code: 200
         validate_certs: "{{ ah_validate_certs | default(omit) }}"


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

modifies the aap_setup_install role to use credentials from the aap_setup_prep_inv_secrets variable if defined

Brief explanation of the code or documentation change you've made

the aap_setup_install role uses controller and hub credentials when checking that the components are running both before and after the setup script is run.  however, it only used credentials defined in `aap_setup_prep_inv_vars`, but according to the aap_setup_prep role they can also be defined in `aap_setup_prep_inv_secrets`.  this PR modifies the tasks to use either, preferring credentials in `aap_setup_prep_inv_secrets` over those in `aap_setup_prep_inv_vars`.

# How should this be tested?

only set controller and hub credentials in `aap_setup_prep_inv_secrets` when installing AAP.  before this change, running the aap_setup_install role would fail when checking if controller or hub were running if the credentials were only set in this variable.

# Is there a relevant Issue open for this?

no

Provide a link to any open issues that describe the problem you are solving.
resolves #[number]

n/a

Please provide link to other PRs that may be related (blocking, resolves, etc. etc.)

n/a