### PR TITLE
update lint

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -14,6 +14,7 @@ use_default_rules: true
 # verbosity: 1
 skip_list:
   - meta-runtime
+  - var-naming[no-role-prefix]
 warn_list:
   - jinja[invalid]  # Temporarily adding this due to https://github.com/ansible/ansible-lint/issues/3048
 ...


### PR DESCRIPTION
# What does this PR do?

Fix linting
we use unique variables and __ as a prefix, but disabling this check for now
