### PR TITLE
Bump default AAP version from 2.3 to 2.4

### DIFF
--- a/roles/aap_setup_download/defaults/main.yml
+++ b/roles/aap_setup_download/defaults/main.yml
@@ -7,7 +7,7 @@
 # aap_setup_down_offline_token:
 
 # which version of the installer to download
-aap_setup_down_version: "2.3"
+aap_setup_down_version: "2.4"
 
 # Which RHEL version are you using (8 or 9)
 aap_setup_rhel_version: "{{ ansible_distribution_major_version | default(8, true) }}"


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Bump default AAP version from 2.3 to 2.4

# How should this be tested?

Just install or upgrade an existing 2.3 installation.

# Is there a relevant Issue open for this?

n/a

# Other Relevant info, PRs, etc

It is the only required change to support AAP 2.4 (not taking yet EDA into account)
