### PR TITLE
add option to configure log directory

### DIFF
--- a/roles/aap_setup_install/README.md
+++ b/roles/aap_setup_install/README.md
@@ -20,6 +20,7 @@ The following input variables are available:
 |`controller_hostname/username/password/validate_certs`|none|see below|hostname and credentials of the installed controller, necessary to test previous installation|see the 'redhat\_cop.controller\_configuration' collection|
 |`ah_hostname/username/password/validate_certs`|none|see below|hostname and credentials of the installed automation hub, necessary to test previous installation|see the 'redhat\_cop.ah\_configuration' collection|
 |`aap_setup_inst_force`|false|no|a boolean deciding if the installation should proceed even if the controller and the automation hub are already installed|see [defaults/main.yml](defaults/main.yml)|
+|`aap_setup_inst_log_dir`|none|no|directory where setup.sh stores the log file|'/tmp/'|
 
 Note that the `controller_` and `ah_` variables are only required if the variable `aap_setup_inst_force` is _not_ true _and_ if the respective service is due to be installed.
 

--- a/roles/aap_setup_install/templates/setup_sh.j2
+++ b/roles/aap_setup_install/templates/setup_sh.j2
@@ -7,3 +7,6 @@
 {%- for varsfile in __extra_vars_files.results %}
  -e @{{ varsfile.dest }}
 {%- endfor -%}
+{%- if aap_setup_inst_log_dir is defined %}
+ -p {{ aap_setup_inst_log_dir }}
+{%- endif -%}


### PR DESCRIPTION
This PR adds an option to configure the directory where `setup.sh` stores the log files. 

Currently this is only implemented for the `aap_setup_install` role. However it makes sense to add this option to all roles which wrap the `setup.sh` script. 