### PR TITLE
fix incorrect download bundle

### DIFF
--- a/roles/aap_setup_download/tasks/main.yml
+++ b/roles/aap_setup_download/tasks/main.yml
@@ -32,7 +32,9 @@
     headers:
       Authorization: "Bearer {{ __aap_setup_down_login.json.access_token }}"
   loop: "{{ __aap_setup_down_images[:3] }}"
-  when: ((aap_setup_down_type | string) + '-' + (aap_setup_down_version | string)) in item.filename
+  when:
+    - ((aap_setup_down_type | string) + '-' + (aap_setup_down_version | string)) in item.filename
+    - not 'containerized-setup' in item.filename
   register: __aap_setup_down_downloads
 
 - name: Extract the name of the downloaded installer to aap_setup_down_installer_file

--- a/roles/aap_setup_download/tasks/main.yml
+++ b/roles/aap_setup_download/tasks/main.yml
@@ -34,7 +34,7 @@
   loop: "{{ __aap_setup_down_images[:3] }}"
   when:
     - ((aap_setup_down_type | string) + '-' + (aap_setup_down_version | string)) in item.filename
-    - not 'containerized-setup' in item.filename
+    - "'ansible-automation-platform-setup' in item.filename"
   register: __aap_setup_down_downloads
 
 - name: Extract the name of the downloaded installer to aap_setup_down_installer_file


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

Incorrect setup bundle is downloaded with 2.4 and RHEL9 version `ansible-automation-platform-containerized-setup`

# How should this be tested?

Detailed bug report is provided here https://github.com/redhat-cop/aap_utilities/issues/199

# Is there a relevant Issue open for this?

Provide a link to any open issues that describe the problem you are solving.
resolves #199 

# Other Relevant info, PRs, etc

Please provide link to other PRs that may be related (blocking, resolves, etc. etc.)
