### PR TITLE
Add the possibility to install EDA controller certificates/keys using the aap_certs role

### DIFF
--- a/roles/aap_certs/README.md
+++ b/roles/aap_certs/README.md
@@ -1,6 +1,6 @@
 # infra.aap\_utilities.aap\_certs
 
-Ansible role to install SSL certificates for AAP automation controller and/or automation hub.
+Ansible role to install SSL certificates for AAP automation controller and/or automation hub and/or EDA controller.
 
 Certificates are only installed if the underlying destination directory does already exist,
 this allows to point the role at all servers in the cluster.
@@ -24,6 +24,9 @@ aap_certs_controller_ssl_cert: "{{ playbook_dir }}/tower.cert"
 aap_certs_controller_ssl_key: "{{ playbook_dir }}/tower.key"
 aap_certs_autohub_ssl_cert: "{{ playbook_dir }}/pulp.cert"
 aap_certs_autohub_ssl_key: "{{ playbook_dir }}/pulp.key"
+aap_certs_eda_ssl_cert: "{{ playbook_dir }}/server.cert"
+aap_certs_eda_ssl_key: "{{ playbook_dir }}/server.key"
+
 ```
 
 The content of the certificates and keys can also be set rather than specifying a file.
@@ -35,6 +38,9 @@ aap_certs_controller_ssl_cert_content: "-----BEGIN CERTIFICATE----- xxxxxx -----
 aap_certs_controller_ssl_key_content: "-----BEGIN PRIVATE KEY----- xxxxxx -----END PRIVATE KEY-----"
 aap_certs_autohub_ssl_cert_content: "-----BEGIN CERTIFICATE----- xxxxxx -----END CERTIFICATE-----"
 aap_certs_autohub_ssl_key_content: "-----BEGIN PRIVATE KEY----- xxxxxx -----END PRIVATE KEY-----"
+aap_certs_eda_ssl_cert_content: "-----BEGIN CERTIFICATE----- xxxxxx -----END CERTIFICATE-----"
+aap_certs_eda_ssl_key_content: "-----BEGIN PRIVATE KEY----- xxxxxx -----END PRIVATE KEY-----"
+
 ```
 
 The following variable defines if the old certificates/keys should be backed-up:

--- a/roles/aap_certs/defaults/main.yml
+++ b/roles/aap_certs/defaults/main.yml
@@ -5,16 +5,22 @@
 #   -keyout tower.key -out tower.cert
 # or
 #   -keyout pulp.key -out pulp.cert
+# or
+#   -keyout server.key -out server.cert
 # aap_certs_controller_ssl_cert: "{{ playbook_dir }}/tower.cert"
 # aap_certs_controller_ssl_key: "{{ playbook_dir }}/tower.key"
 # aap_certs_autohub_ssl_cert: "{{ playbook_dir }}/pulp.cert"
 # aap_certs_autohub_ssl_key: "{{ playbook_dir }}/pulp.key"
+# aap_certs_eda_ssl_cert: "{{ playbook_dir }}/server.cert"
+# aap_certs_eda_ssl_key: "{{ playbook_dir }}/server.key"
 #
 # content of the certificates and keys (mutex with above vars)
 # aap_certs_controller_ssl_cert_content: "-----BEGIN CERTIFICATE----- xxxxxx -----END CERTIFICATE-----"
 # aap_certs_controller_ssl_key_content: "-----BEGIN PRIVATE KEY----- xxxxxx -----END PRIVATE KEY-----"
 # aap_certs_autohub_ssl_cert_content: "-----BEGIN CERTIFICATE----- xxxxxx -----END CERTIFICATE-----"
 # aap_certs_autohub_ssl_key_content: "-----BEGIN PRIVATE KEY----- xxxxxx -----END PRIVATE KEY-----"
+# aap_certs_eda_ssl_cert_content: "-----BEGIN CERTIFICATE----- xxxxxx -----END CERTIFICATE-----"
+# aap_certs_eda_ssl_key_content: "-----BEGIN PRIVATE KEY----- xxxxxx -----END PRIVATE KEY-----"
 
 # boolean to decide if the existing certificates are kept
 aap_certs_create_backup: false

--- a/roles/aap_certs/tasks/edacontroller.yml
+++ b/roles/aap_certs/tasks/edacontroller.yml
@@ -1,0 +1,35 @@
+---
+- name: EDA Controller | get certificate file content
+  when:
+    - aap_certs_eda_ssl_cert is defined
+    - aap_certs_eda_ssl_key is defined
+  ansible.builtin.set_fact:
+    aap_certs_eda_ssl_cert_content: "{{ lookup('ansible.builtin.file', aap_certs_eda_ssl_cert) }}"
+    aap_certs_eda_ssl_key_content: "{{ lookup('ansible.builtin.file', aap_certs_eda_ssl_key) }}"
+
+- name: EDA Controller | update certificate file
+  become: true
+  ansible.builtin.template:
+    src: cert_content.j2
+    dest: "{{ aap_certs_eda_cert_dest }}"
+    mode: u=rw,go=
+    owner: root
+    group: eda
+    backup: "{{ aap_certs_create_backup }}"
+  notify: restart_aap_service
+  vars:
+    file_content: "{{ aap_certs_eda_ssl_cert_content }}"
+
+- name: EDA Controller | update certificate key file
+  become: true
+  ansible.builtin.template:
+    src: cert_content.j2
+    dest: "{{ aap_certs_eda_key_dest }}"
+    mode: u=rw,go=
+    owner: root
+    group: eda
+    backup: "{{ aap_certs_create_backup }}"
+  notify: restart_aap_service
+  vars:
+    file_content: "{{ aap_certs_eda_ssl_key_content }}"
+...

--- a/roles/aap_certs/tasks/main.yml
+++ b/roles/aap_certs/tasks/main.yml
@@ -24,4 +24,18 @@
     - __aap_certs_autohub_dir.stat.exists
     - aap_certs_autohub_ssl_cert is defined or aap_certs_autohub_ssl_cert_content is defined
     - aap_certs_autohub_ssl_key is defined or aap_certs_autohub_ssl_key_content is defined
+
+- name: Validate if eda controller certificates directory exists
+  become: true
+  ansible.builtin.stat:
+    path: "{{ aap_certs_eda_cert_dest | dirname }}"
+  register: __aap_certs_eda_dir
+
+- name: Install certificates for eda controller if directory exists
+  ansible.builtin.include_tasks: edacontroller.yml
+  when:
+    - __aap_certs_eda_dir.stat.exists
+    - aap_certs_eda_ssl_cert is defined or aap_certs_eda_ssl_cert_content is defined
+    - aap_certs_eda_ssl_key is defined or aap_certs_eda_ssl_key_content is defined
+
 ...

--- a/roles/aap_certs/vars/main.yml
+++ b/roles/aap_certs/vars/main.yml
@@ -3,4 +3,6 @@ aap_certs_controller_cert_dest: /etc/tower/tower.cert
 aap_certs_controller_key_dest: /etc/tower/tower.key
 aap_certs_autohub_cert_dest: /etc/pulp/certs/pulp_webserver.crt
 aap_certs_autohub_key_dest: /etc/pulp/certs/pulp_webserver.key
+aap_certs_eda_cert_dest: /etc/ansible-automation-platform/eda/server.cert
+aap_certs_eda_key_dest: /etc/ansible-automation-platform/eda/server.key
 ...


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

Add the possibility to install EDA controller certificates/keys using the aap_certs role

# How should this be tested?

cat aap_certs.yml 
---
- name: Install AAP certificates
  hosts: aap_eda
  become: true
  vars:
    aap_certs_eda_ssl_cert: "{{ playbook_dir }}/server.cert"
    aap_certs_eda_ssl_key: "{{ playbook_dir }}/server.key"
  roles:
    - aap_certs

$ ansible-playbook -i ../aap_inventory/inventory aap_certs.yml