### PR TITLE
Added support for providing OpenShift auth via api key

### DIFF
--- a/roles/aap_ocp_install/README.md
+++ b/roles/aap_ocp_install/README.md
@@ -27,9 +27,12 @@ If the variable is omitted the corresponding component will not be installed (e.
 | Key Name       | Required | Default Value | Description                                                  |
 |----------------|:--------:|---------------|--------------------------------------------------------------|
 | host           | Yes      | None          | OCP cluster to create the AAP objects in                     |
-| username       | Yes      | None          | Username to use for authenticating with OCP                  |
-| password       | Yes      | None          | Password to use for authenticating with OCP                  |
+| username       | Yes*     | None          | Username to use for authenticating with OCP                  |
+| password       | Yes*     | None          | Password to use for authenticating with OCP                  |
+| api_key        | Yes*     | None          | OCP API Token                                                |
 | validate_certs |          | None          | Validate SSL certificates. Valid values are: `true`, `false` |
+
+\* Either `api_key` or `username` and `password` can be specified.
 
 ### aap_ocp_install_operator keys
 

--- a/roles/aap_ocp_install/defaults/main.yml
+++ b/roles/aap_ocp_install/defaults/main.yml
@@ -4,6 +4,7 @@
 #   host:
 #   username:
 #   password:
+#   api_key:
 #   verify_ssl:
 
 # Namespace to install into

--- a/roles/aap_ocp_install/tasks/finalization.yml
+++ b/roles/aap_ocp_install/tasks/finalization.yml
@@ -1,6 +1,6 @@
 ---
 - name: "If login succeeded revoke OpenShift API token"
-  when: __aap_ocp_install_auth_results['openshift_auth']['api_key'] is defined
+  when: __aap_ocp_install_auth_results['openshift_auth']['api_key'] is defined and aap_ocp_install_connection['api_key'] is not defined
   # Disabling check for FQCN on module names as using either community.okd or redhat.openshift collection is able to be used
   openshift_auth:  # noqa fqcn[action]
     host: "{{ aap_ocp_install_connection['host'] | mandatory }}"

--- a/roles/aap_ocp_install/tasks/initialization.yml
+++ b/roles/aap_ocp_install/tasks/initialization.yml
@@ -7,6 +7,16 @@
     password: "{{ aap_ocp_install_connection['password'] | mandatory }}"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
   register: __aap_ocp_install_auth_results
+  when: aap_ocp_install_connection['api_key'] is not defined
+
+- name: Set authentication for provided API key
+  ansible.builtin.set_fact:
+    __aap_ocp_install_auth_results:
+      openshift_auth:
+        host: "{{ aap_ocp_install_connection['host'] | mandatory }}"
+        api_key: "{{ aap_ocp_install_connection['api_key'] | mandatory }}"
+        validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
+  when: aap_ocp_install_connection['api_key'] is defined
 
 - name: Create namespace
   kubernetes.core.k8s:

--- a/roles/aap_ocp_install/tasks/pre-validate.yml
+++ b/roles/aap_ocp_install/tasks/pre-validate.yml
@@ -13,7 +13,38 @@
         __aap_ocp_install_prevalidate_errors: >
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_connection['host'] must be set"] }}
 
+- name: Ensure OpenShift username and password variables are not set when API Token set (block)
+  when: aap_ocp_install_connection['api_key'] is defined
+  block:
+    - name: Ensure OpenShift username and password variables are not set when API Token set
+      ansible.builtin.assert:
+        that:
+          - aap_ocp_install_connection['username'] is not defined
+          - aap_ocp_install_connection['password'] is not defined
+        quiet: true
+  rescue:
+    - name: Update validation errors fact - username
+      ansible.builtin.set_fact:
+        __aap_ocp_install_prevalidate_errors: >
+          {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_connection['username'] or aap_ocp_install_connection['password'] must not be set when aap_ocp_install_connection['api_key'] is set"] }}
+
+- name: Ensure OpenShift API token variable is set (block)
+  when: aap_ocp_install_connection['api_key'] is defined
+  block:
+    - name: Ensure OpenShift API token variable is set
+      ansible.builtin.assert:
+        that:
+          - aap_ocp_install_connection['api_key'] is defined
+          - aap_ocp_install_connection['api_key'] | default("", true) | length > 0
+        quiet: true
+  rescue:
+    - name: Update validation errors fact - api_key
+      ansible.builtin.set_fact:
+        __aap_ocp_install_prevalidate_errors: >
+          {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_connection['api_key'] must be set"] }}
+
 - name: Ensure OpenShift username variable is set (block)
+  when: aap_ocp_install_connection['api_key'] is not defined
   block:
     - name: Ensure OpenShift username variable is set
       ansible.builtin.assert:
@@ -28,6 +59,7 @@
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_connection['username'] must be set"] }}
 
 - name: Ensure OpenShift password variable is set (block)
+  when: aap_ocp_install_connection['api_key'] is not defined
   block:
     - name: Ensure OpenShift password variable is set
       ansible.builtin.assert:


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

Adds support for authenticating to OpenShift via an API key (token) instead of a username and password

# How should this be tested?

Invoke the `ocp_install` role and provide the following variables:

```yaml
aap_ocp_install_connection:
  host: "<host>"
  api_key: "<api_key>"
  validate_certs: false
```

# Is there a relevant Issue open for this?

No