### PR TITLE
Make inventory file mode 600

### DIFF
--- a/roles/aap_setup_prepare/tasks/main.yml
+++ b/roles/aap_setup_prepare/tasks/main.yml
@@ -34,7 +34,7 @@
   ansible.builtin.template:
     src: inventory.j2
     dest: "{{ aap_setup_prep_setup_dir }}/inventory"
-    mode: "ug=rw,o=r"
+    mode: "600"
   when: aap_setup_prep_process_template | bool
 
 - name: Apply relevant fixes / workarounds

--- a/roles/aap_setup_prepare/tasks/main.yml
+++ b/roles/aap_setup_prepare/tasks/main.yml
@@ -34,7 +34,7 @@
   ansible.builtin.template:
     src: inventory.j2
     dest: "{{ aap_setup_prep_setup_dir }}/inventory"
-    mode: "600"
+    mode: "640"
   when: aap_setup_prep_process_template | bool
 
 - name: Apply relevant fixes / workarounds


### PR DESCRIPTION
The inventory file that aap_setup_prepare generates contains a lot of credentials, but has very unsafe permissions (664) at the moment.

This commit changes it to 600 permissions.

fixes #237
