### PR TITLE
fix download, add containerized download documentation

### DIFF
--- a/changelogs/fragments/download_fix_and_update.yml
+++ b/changelogs/fragments/download_fix_and_update.yml
@@ -1,0 +1,7 @@
+---
+bugfixes:
+  - Fixed an issue where where download would error trying to download a second version of the installer.
+minor_changes:
+  - Added ability to download the containerized installer.
+  - Tweaked how the installer to download is choosen, this should have no effective changes.
+...

--- a/roles/aap_setup_download/README.md
+++ b/roles/aap_setup_download/README.md
@@ -19,7 +19,7 @@ It has no default value and _must_ be defined.
 The default is the latest version available at time of writing.
 * `aap_setup_down_dest_dir` is the directory to where you want to download the tarball.
 It is by default the working directory `aap_setup_working_dir` also used by other roles of the collection, or ultimately `/var/tmp`.
-* `aap_setup_down_type` can be either `setup` or `setup-bundle`, depending which flavour of the tarball you want to download.
+* `aap_setup_down_type` can be either `setup`, `setup-bundle`, `containerized-setup`, depending which flavour of the tarball you want to download.
 * `aap_setup_rhel_version` defines the major RHEL version being used (currently 8 or 9). If you are gathering facts you possibly don't need to specify this as the role will attempt to work out the value required though you will if AAP will be installed on machines on a different OS than the installer will run on. Otherwise the default is 8.
 * `aap_setup_containerized` if set to `true` the role will download the the containerized installer.
 * `aap_setup_arch` define the processor architecture of the installer. Default to "x86_64"

--- a/roles/aap_setup_download/tasks/main.yml
+++ b/roles/aap_setup_download/tasks/main.yml
@@ -20,24 +20,20 @@
       Authorization: "Bearer {{ __aap_setup_down_login.json.access_token }}"
   register: __aap_setup_down_output
 
-- name: Simplify the list of possible downloads
+- name: Select the Specified installer to download
   ansible.builtin.set_fact:
-    __aap_setup_down_images: "{{ __aap_setup_down_output.json.body | selectattr('filename', 'match', ((aap_setup_containerized | bool) | ternary('ansible-automation-platform-containerized-setup', 'ansible-automation-platform-setup'))) | sort(attribute='datePublished', reverse=True) }}"
+    __aap_setup_down_images: "{{ __aap_setup_down_output.json.body | selectattr('filename', 'match', ((aap_setup_containerized | bool) | ternary('ansible-automation-platform-containerized-setup', 'ansible-automation-platform-setup'))) | sort(attribute='datePublished', reverse=True) | selectattr('filename', 'search', (aap_setup_down_type | string) + '-' + (aap_setup_down_version | string)) }}"
 
 - name: Downloading the latest installer of type {{ aap_setup_down_type }}
   ansible.builtin.get_url:
-    url: "{{ item.downloadHref }}"
-    dest: "{{ aap_setup_down_dest_dir }}/{{ item.filename }}"
+    url: "{{ __aap_setup_down_images[:3][0].downloadHref }}"
+    dest: "{{ aap_setup_down_dest_dir }}/{{ __aap_setup_down_images[:3][0].filename }}"
     mode: 0644
     headers:
       Authorization: "Bearer {{ __aap_setup_down_login.json.access_token }}"
-  loop: "{{ __aap_setup_down_images[:3] }}"
-  when:
-    - ((aap_setup_down_type | string) + '-' + (aap_setup_down_version | string)) in item.filename
-    - ((aap_setup_containerized | bool) | ternary('ansible-automation-platform-containerized-setup', 'ansible-automation-platform-setup')) in item.filename
   register: __aap_setup_down_downloads
 
 - name: Extract the name of the downloaded installer to aap_setup_down_installer_file
   ansible.builtin.set_fact:
-    aap_setup_down_installer_file: "{{ (__aap_setup_down_downloads.results | selectattr('dest', 'defined') | map(attribute='dest') | list)[0] }}"
+    aap_setup_down_installer_file: "{{ __aap_setup_down_downloads.dest }}"
 ...


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

bugfixes:
  - Fixed an issue where where download would error trying to download a second version of the installer.
 
minor_changes:
  - Added ability to download the containerized installer.
  - Tweaked how the installer to download is choosen, this should have no effective changes.

# How should this be tested?

Already tested, this will error out if someone tries to download the containerized for rhel 8, as it doesn't exist, but don't have a great way of preventing that.

# Is there a relevant Issue open for this?

Provide a link to any open issues that describe the problem you are solving.
resolves #226 
