### PR TITLE
fix generated inventory files without a database inventory group

### DIFF
--- a/roles/aap_setup_prepare/templates/inventory.j2
+++ b/roles/aap_setup_prepare/templates/inventory.j2
@@ -1,11 +1,15 @@
 {# output all the hosts and their groups #}
 
 {% for group_key in aap_setup_prep_inv_nodes %}
+
+{%if group_key in groups %}
 [{{ group_key }}]
 {% for node_key in aap_setup_prep_inv_nodes[group_key] %}
 {{ node_key }}{% if aap_setup_prep_inv_nodes[group_key][node_key] is defined %} {{ aap_setup_prep_inv_nodes[group_key][node_key] }}{% endif %}
 
 {% endfor %}
+
+{% endif %}
 
 {% endfor %}
 


### PR DESCRIPTION
Without the control on the existence of the groups in the inventory file, not having a database section in the inventory generates a malformed inventory file.

<!--- markdownlint-disable MD041 -->
# What does this PR do?

Without the control on the existence of the groups in the inventory file, not having a database section in the inventory generates a malformed inventory file.

