### PR TITLE
Enable the ability to override OpenShift manifests

### DIFF
--- a/roles/aap_ocp_install/README.md
+++ b/roles/aap_ocp_install/README.md
@@ -11,13 +11,15 @@ In addition the kubernetes.core and redhat.openshift Ansible collections are req
 
 A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
 
-| Variable Name              | Required | Default Value | Description                                                            |
-|----------------------------|:--------:|---------------|------------------------------------------------------------------------|
-| aap_ocp_install_namespace  | Yes      | None          | Namespace to create operator, controller, and hub in                   |
-| aap_ocp_install_connection | Yes      | None          | Dictionary containing keys defined in the `connection variables table` |
-| aap_ocp_install_operator   | Yes*     | None          | Dictionary containing keys defined in the `operator variables table`   |
-| aap_ocp_install_controller | Yes*     | None          | Dictionary containing keys defined in the `controller variables table` |
-| aap_ocp_install_hub        | Yes*     | None          | Dictionary containing keys defined in the `hub variables table`        |
+| Variable Name                                | Required | Default Value | Description                                                                                  |
+|----------------------------------------------|:--------:|---------------|----------------------------------------------------------------------------------------------|
+| aap_ocp_install_namespace                    | Yes      | None          | Namespace to create operator, controller, and hub in                                         |
+| aap_ocp_install_create_namespace             | No       | None          | Create the Namespace for the operator, controller and hub. Valid values are: `true`, `false` |
+| aap_ocp_install_namespace_manifest_overrides | No       | None          | Namespace to create operator, controller, and hub in                                         |
+| aap_ocp_install_connection                   | Yes      | None          | Dictionary containing keys defined in the `connection variables table`                       |
+| aap_ocp_install_operator                     | Yes*     | None          | YAML Manifest to override the generated operator `Namespace` resource                        |
+| aap_ocp_install_controller                   | Yes*     | None          | Dictionary containing keys defined in the `controller variables table`                       |
+| aap_ocp_install_hub                          | Yes*     | None          | Dictionary containing keys defined in the `hub variables table`                              |
 
 \* Variable and required keys must be defined when the type of tag is specified (e.g. `--tags controller` requires the aap_ocp_install_controller variable be defined).
 If the variable is omitted the corresponding component will not be installed (e.g. if only aap_ocp_install_hub variable is defined then the operator and controller installation will be skipped)
@@ -36,10 +38,13 @@ If the variable is omitted the corresponding component will not be installed (e.
 
 ### aap_ocp_install_operator keys
 
-| Key Name | Required | Default Value | Description                                                         |
-|----------|:--------:|---------------|---------------------------------------------------------------------|
-| channel  | Yes      | None          | Channel to subscribe (e.g. stable-2.2 or stable-2.2-cluster-scoped) |
-| approval |          | Automatic     | Update approval method. Valid values are Automatic or Manual.       |
+| Key Name                         | Required  | Default Value | Description                                                         |
+|----------------------------------|:---------:|---------------|---------------------------------------------------------------------|
+| channel                          | Yes       | None          | Channel to subscribe (e.g. stable-2.2 or stable-2.2-cluster-scoped) |
+| approval                         |           | Automatic     | Update approval method. Valid values are Automatic or Manual.       |
+| operatorgroup_create             |           | true          | Create the `OperatorGroup` for the Operator                         |
+| operatorgroup_manifest_overrides |           |               | YAML Manifest to override the generated `OperatorGroup` resource    |
+| subscription_manifest_overrides  |           |               | YAML Manifest to override the generated `Subscription` resource     |
 
 > ℹ️ **NOTE**
 >
@@ -47,32 +52,43 @@ If the variable is omitted the corresponding component will not be installed (e.
 
 ### aap_ocp_install_controller keys
 
-| Key Name                     | Required | Default Value                           | Description                                                                                                            |
-|------------------------------|:--------:|-----------------------------------------|------------------------------------------------------------------------------------------------------------------------|
-| instance_name                | Yes      | None                                    | Name of the controller instance to create                                                                              |
-| namespace                    |          | None                                    | Name of the namespace to create the controller instance in. If not specified `aap_ocp_install_namespace` will be used. |
-| admin_user                   |          | admin                                   | Username to use for the admin account                                                                                  |
-| replicas                     |          | 1                                       | How many replicas to create.                                                                                           |
-| garbage_collect_secrets      |          | false                                   | Whether or not to remove secrets upon instance removal                                                                 |
-| image_pull_policy            |          | IfNotPresent                            | The image pull policy                                                                                                  |
-| create_preload_data          |          | true                                    | Whether or not to preload data upon instance creation                                                                  |
-| projects_persistence         |          | false                                   | Whether or not the /var/lib/projects directory will be persistent                                                      |
-| projects_storage_size        |          | 8Gi                                     | Size of /var/lib/projects persistent volume claim (PVC)                                                                |
-| link_text                    |          | Automation Controller (<INSTANCE_NAME>) | Text used for creating the OCP application link                                                                        |
+| Key Name                       | Required | Default Value                           | Description                                                                                                            |
+|--------------------------------|:--------:|-----------------------------------------|------------------------------------------------------------------------------------------------------------------------|
+| instance_name                  | Yes      | None                                    | Name of the controller instance to create                                                                              |
+| namespace                      |          | None                                    | Name of the namespace to create the controller instance in. If not specified `aap_ocp_install_namespace` will be used. |
+| namespace_manifest_overrides   |          | None                                    | YAML Manifest to override the generated `Namespace` resource for the controller if the `namespace` key is defined |
+| admin_user                     |          | admin                                   | Username to use for the admin account                                                                                  |
+| replicas                       |          | 1                                       | How many replicas to create.                                                                                           |
+| garbage_collect_secrets        |          | false                                   | Whether or not to remove secrets upon instance removal                                                                 |
+| image_pull_policy              |          | IfNotPresent                            | The image pull policy                                                                                                  |
+| create_preload_data            |          | true                                    | Whether or not to preload data upon instance creation                                                                  |
+| projects_persistence           |          | false                                   | Whether or not the /var/lib/projects directory will be persistent                                                      |
+| projects_storage_size          |          | 8Gi                                     | Size of /var/lib/projects persistent volume claim (PVC)                                                                |
+| link_text                      |          | Automation Controller (<INSTANCE_NAME>) | Text used for creating the OCP application link                                                                        |
+| controller_manifest_overrides  |          | None                           | YAML Manifest to override the generated `AutomationController` resource link                                                                        |
+| consolelink_manifest_overrides |          | None                           | YAML Manifest to override the generated `ConsoleLink` resource                                                                         |
 
 ### aap_ocp_install_hub keys
 
-| Key Name      | Required | Default Value                    | Description                                     |
-|---------------|:--------:|----------------------------------|-------------------------------------------------|
-| instance_name | Yes      | None                             | Name of the hub instance to create              |
-| link_text     |          | Automation Hub (<INSTANCE_NAME>) | Text used for creating the OCP application link |
+| Key Name                           | Required | Default Value                    | Description                                                       |
+|------------------------------------|:--------:|----------------------------------|-------------------------------------------------------------------|
+| instance_name                      | Yes      | None                             | Name of the hub instance to create                                |
+| namespace                          |          | None                             | Name of the namespace to create the hub instance in. If not specified `aap_ocp_install_namespace` will be used. |
+| namespace_manifest_overrides       |          | None                             | YAML Manifest to override the generated `Namespace` resource for the hub if the `namespace` key is defined |
+| link_text                          |          | Automation Hub (<INSTANCE_NAME>) | Text used for creating the OCP application link                   |
+| hub_manifest_overrides             |          | None                             | YAML Manifest to override the generated `AutomationHub` resource  |
+| consolelink_manifest_overrides     |          | None                             | YAML Manifest to override the generated `ConsoleLink` resource    |
 
 ### aap_ocp_install_eda keys
 
 | Key Name      | Required | Default Value                    | Description                                     |
-|---------------|:--------:|----------------------------------|-------------------------------------------------|
-| instance_name | Yes      | None                             | Name of the EDA instance to create              |
-| link_text     |          | EDA Controller (<INSTANCE_NAME>) | Text used for creating the OCP application link |
+|------------------------------------|:--------:|----------------------------------|-------------------------------------------------|
+| instance_name                      | Yes      | None                             | Name of the EDA instance to create              |
+| namespace                          |          | None                             | Name of the namespace to create the EDA instance in. If not specified `aap_ocp_install_namespace` will be used. |
+| namespace_manifest_overrides       |          | None                             | YAML Manifest to override the generated `Namespace` resource for the EDA if the `namespace` key is defined |
+| link_text                          |          | EDA Controller (<INSTANCE_NAME>) | Text used for creating the OCP application link |
+| eda_manifest_overrides             |          | None                             | YAML Manifest to override the generated `EDA` resource  |
+| consolelink_manifest_overrides     |          | None                             | YAML Manifest to override the generated `ConsoleLink` resource    |
 
 ## Dependencies
 
@@ -115,5 +131,6 @@ Including an example of how to use your role (for instance, with variables passe
 
 ## Author Information
 
-Brant Evans
-Derek Waters
+* Brant Evans
+* Derek Waters
+* Andrew Block

--- a/roles/aap_ocp_install/tasks/initialization.yml
+++ b/roles/aap_ocp_install/tasks/initialization.yml
@@ -19,12 +19,13 @@
   when: aap_ocp_install_connection['api_key'] is defined
 
 - name: Create namespace
+  when: aap_ocp_install_create_namespace | default(true) | bool
   kubernetes.core.k8s:
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
     state: present
-    resource_definition: "{{ lookup('ansible.builtin.template', 'namespace.yaml.j2', template_vars=ns_vars) | from_yaml }}"
+    resource_definition: "{{ lookup('ansible.builtin.template', 'namespace.yaml.j2', template_vars=ns_vars) | from_yaml | ansible.builtin.combine(aap_ocp_install_namespace_manifest_overrides | default({}), recursive=true) }}"
     apply: true
   vars:
     ns_vars:

--- a/roles/aap_ocp_install/tasks/install-controller.yml
+++ b/roles/aap_ocp_install/tasks/install-controller.yml
@@ -5,7 +5,7 @@
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
     state: present
-    resource_definition: "{{ lookup('ansible.builtin.template', 'namespace.yaml.j2', template_vars=ns_vars) | from_yaml }}"
+    resource_definition: "{{ lookup('ansible.builtin.template', 'namespace.yaml.j2', template_vars=ns_vars) | from_yaml | ansible.builtin.combine(aap_ocp_install_controller['namespace_manifest_overrides'] | default({}), recursive=true) }}"
     apply: true
   vars:
     ns_vars:
@@ -19,7 +19,7 @@
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
     state: present
-    resource_definition: "{{ lookup('template', 'controller/instance.yaml.j2') | from_yaml }}"
+    resource_definition: "{{ lookup('template', 'controller/instance.yaml.j2') | from_yaml | ansible.builtin.combine(aap_ocp_install_controller['controller_manifest_overrides'] | default({}), recursive=true) }}"
     apply: true
 
 - name: Wait for operator to create the automation controller route
@@ -58,6 +58,6 @@
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
     state: present
-    resource_definition: "{{ lookup('template', 'controller/consolelink.yaml.j2') | from_yaml }}"
+    resource_definition: "{{ lookup('template', 'controller/consolelink.yaml.j2') | from_yaml | ansible.builtin.combine(aap_ocp_install_controller['consolelink_manifest_overrides'] | default({}), recursive=true) }}"
     apply: true
 ...

--- a/roles/aap_ocp_install/tasks/install-eda.yml
+++ b/roles/aap_ocp_install/tasks/install-eda.yml
@@ -5,7 +5,7 @@
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
     state: present
-    resource_definition: "{{ lookup('ansible.builtin.template', 'namespace.yaml.j2', template_vars=ns_vars) | from_yaml }}"
+    resource_definition: "{{ lookup('ansible.builtin.template', 'namespace.yaml.j2', template_vars=ns_vars) | from_yaml | ansible.builtin.combine(aap_ocp_install_eda['namespace_manifest_overrides'] | default({}), recursive=true) }}"
     apply: true
   vars:
     ns_vars:
@@ -19,7 +19,7 @@
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
     state: present
-    resource_definition: "{{ lookup('template', 'eda/instance.yaml.j2') | from_yaml }}"
+    resource_definition: "{{ lookup('template', 'eda/instance.yaml.j2') | from_yaml | ansible.builtin.combine(aap_ocp_install_eda['eda_manifest_overrides'] | default({}), recursive=true) }}"
     apply: true
 
 - name: Wait for operator to create the EDA route
@@ -58,6 +58,6 @@
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
     state: present
-    resource_definition: "{{ lookup('template', 'eda/consolelink.yaml.j2') | from_yaml }}"
+    resource_definition: "{{ lookup('template', 'eda/consolelink.yaml.j2') | from_yaml | ansible.builtin.combine(aap_ocp_install_eda['consolelink_manifest_overrides'] | default({}), recursive=true) }}"
     apply: true
 ...

--- a/roles/aap_ocp_install/tasks/install-hub.yml
+++ b/roles/aap_ocp_install/tasks/install-hub.yml
@@ -5,7 +5,7 @@
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
     state: present
-    resource_definition: "{{ lookup('template', 'hub/instance.yaml.j2') | from_yaml }}"
+    resource_definition: "{{ lookup('template', 'hub/instance.yaml.j2') | from_yaml | ansible.builtin.combine(aap_ocp_install_hub['namespace_manifest_overrides'] | default({}), recursive=true) }}"
     apply: true
 
 - name: Wait for operator to create the automation hub route
@@ -44,6 +44,6 @@
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
     state: present
-    resource_definition: "{{ lookup('template', 'hub/consolelink.yaml.j2') | from_yaml }}"
+    resource_definition: "{{ lookup('template', 'hub/consolelink.yaml.j2') | from_yaml | ansible.builtin.combine(aap_ocp_install_hub['hub_manifest_overrides'] | default({}), recursive=true) }}"
     apply: true
 ...

--- a/roles/aap_ocp_install/tasks/install-operator.yml
+++ b/roles/aap_ocp_install/tasks/install-operator.yml
@@ -1,11 +1,12 @@
 ---
 - name: Create operator group
+  when: operatorgroup_create | default(true) | bool
   kubernetes.core.k8s:
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
     state: present
-    resource_definition: "{{ lookup('template', 'operator/operatorgroup.yaml.j2') | from_yaml }}"
+    resource_definition: "{{ lookup('template', 'operator/operatorgroup.yaml.j2') | from_yaml | ansible.builtin.combine(aap_ocp_install_operator['operatorgroup_manifest_overrides'] | default({}), recursive=true) }}"
     apply: true
 
 - name: Create subscription
@@ -14,7 +15,7 @@
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
     state: present
-    resource_definition: "{{ lookup('template', 'operator/subscription.yaml.j2') | from_yaml }}"
+    resource_definition: "{{ lookup('template', 'operator/subscription.yaml.j2') | from_yaml | ansible.builtin.combine(aap_ocp_install_operator['subscription_manifest_overrides'] | default({}), recursive=true) }}"
     apply: true
 
 - name: Wait for operator installation to complete


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
The `aap_ocp_install` role enables the creation of OpenShift manifests to deploy AAP. However, the manifests that are generated only cover a fraction of the available parameters for each of the resources that it manages.

This PR introduces the concept of `manifest_overrides` which enables the ability to specify values for each of the OpenShift items managed by this role. 

For example to be able to specify the number of Automation Controller task replicas, the following can be set.

```yaml
aap_ocp_install_controller:
  controller_manifest_overrides:
    spec:
      task_replicas: 2
```

# How should this be tested?

Utilize the example shown above in a playbook similar to the following

```yaml
- name: Testing
  hosts: localhost
  vars:
    aap_ocp_install_controller:
      instance_name: "aap1"
      controller_manifest_overrides:
        spec:
          task_replicas: 2
    aap_ocp_install_operator:
      channel: 'stable-2.4'

  tasks:
    - name: Import aap_ocp_install Role
      ansible.builtin.include_role:
        name: aap_ocp_install
```

Confirm that `task_replicas: 2` is present on the `AutomationController` resource.

# Is there a relevant Issue open for this?

No

# Other Relevant info, PRs, etc

None
