### PR TITLE
added support for installing AAP 2.5

### DIFF
--- a/changelogs/fragments/add_aap25_support.yaml
+++ b/changelogs/fragments/add_aap25_support.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Added support to install latest AAP 2.5 version

--- a/roles/aap_setup_download/README.md
+++ b/roles/aap_setup_download/README.md
@@ -15,7 +15,7 @@ The following input variables are required:
 
 * `aap_setup_down_offline_token` contains your offline token as described in the requirements.
 It has no default value and _must_ be defined.
-* `aap_setup_down_version` defines the minor version to download (e.g. `2.1`)
+* `aap_setup_down_version` defines the minor version to download (e.g. `2.5`). Defaults to current latest `2.5` version.
 The default is the latest version available at time of writing.
 * `aap_setup_down_dest_dir` is the directory to where you want to download the tarball.
 It is by default the working directory `aap_setup_working_dir` also used by other roles of the collection, or ultimately `/var/tmp`.

--- a/roles/aap_setup_download/defaults/main.yml
+++ b/roles/aap_setup_download/defaults/main.yml
@@ -7,7 +7,7 @@
 # aap_setup_down_offline_token:
 
 # which version of the installer to download
-aap_setup_down_version: "2.4"
+aap_setup_down_version: "2.5"
 
 # Which system architecture to dowload for
 aap_setup_arch: x86_64

--- a/roles/aap_setup_download/tasks/main.yml
+++ b/roles/aap_setup_download/tasks/main.yml
@@ -38,4 +38,8 @@
 - name: Extract the name of the downloaded installer to aap_setup_down_installer_file
   ansible.builtin.set_fact:
     aap_setup_down_installer_file: "{{ __aap_setup_down_downloads.dest }}"
+
+- name: Set aap_setup_down_version fact
+  ansible.builtin.set_fact:
+    aap_setup_down_version: "{{ aap_setup_down_version }}"
 ...

--- a/roles/aap_setup_install/README.md
+++ b/roles/aap_setup_install/README.md
@@ -13,6 +13,7 @@ The following input variables are available:
 
 |Variable Name|Default Value|Required|Description|Example|
 |---:|:---:|:---:|:---|:---:|
+|`aap_setup_down_version`|"`{{ aap_setup_down_version }}`"|no|defines the minor version to download (e.g. 2.5), note that `aap_setup_down_version` is a fact set by the role `aap_setup_download`|'2.5'|
 |`aap_setup_inst_setup_dir`|"`{{ aap_setup_prep_setup_dir }}`"|no|absolute path where to find the extracted installation tarball on the remote host, note that `aap_setup_prep_setup_dir` is a fact set by the role `aap_setup_prepare`|'/var/tmp/myinstaller'|
 |`aap_setup_inst_inventory`|"`inventory`"|no|path to the inventory file/directory to be used for the installation, the path can be absolute or relative to the previous directory|'/etc/ansible/inventory'|
 |`aap_setup_inst_extra_vars`|`{}`|no|dictionary of extra vars to use when calling setup.sh|see [defaults/main.yml](defaults/main.yml)|

--- a/roles/aap_setup_install/defaults/main.yml
+++ b/roles/aap_setup_install/defaults/main.yml
@@ -1,6 +1,9 @@
 ---
 # defaults file for aap_setup_install
 
+# which version of the installer to download
+aap_setup_down_version: "{{ aap_setup_down_version }}"
+
 # where is the setup directory
 aap_setup_inst_setup_dir: "{{ aap_setup_prep_setup_dir }}"
 
@@ -71,6 +74,14 @@ ah_hostname: "{{ (aap_setup_prep_inv_nodes['automationhub'].keys() | list)[0] }}
 
 eda_hostname: "{{ (aap_setup_prep_inv_nodes[__aap_setup_inst_eda_group_name].keys() | list)[0] }}"
 # eda_validate_certs: false
+
+# gateway_hostname: "{{ inventory_hostname }}"
+gateway_hostname: "{{ (aap_setup_prep_inv_nodes['automationgateway'].keys() | list)[0] }}"
+# gateway_username: "admin"
+# gateway_password: ""
+# gateway_oauthtoken: ""
+# gateway_config_file: ""
+# gateway_validate_certs: false
 
 # force the installation of AAP even if it's already running
 aap_setup_inst_force: false

--- a/roles/aap_setup_install/tasks/setup.yml
+++ b/roles/aap_setup_install/tasks/setup.yml
@@ -12,6 +12,7 @@
   failed_when: false
   when:
     - "'automationcontroller' in aap_setup_prep_inv_nodes"
+    - aap_setup_down_version is version('2.5', '<')
     - not aap_setup_inst_force | bool
 
 - name: Check Automation Hub Running
@@ -27,6 +28,7 @@
   failed_when: false
   when:
     - "'automationhub' in aap_setup_prep_inv_nodes"
+    - aap_setup_down_version is version('2.5', '<')
     - not aap_setup_inst_force | bool
 
 - name: Check EDA Controller Running
@@ -34,8 +36,7 @@
     url: https://{{ eda_hostname }}/
     method: GET
     user: admin
-    password: "{{ aap_setup_prep_inv_secrets.all.automationedacontroller_admin_password | default(aap_setup_prep_inv_vars.all.automationedacontroller_admin_password)
-      }}"
+    password: "{{ aap_setup_prep_inv_secrets.all.automationedacontroller_admin_password | default(aap_setup_prep_inv_vars.all.automationedacontroller_admin_password) }}"
     validate_certs: "{{ eda_validate_certs | default('false') }}"
     force_basic_auth: true
   register: __aap_setup_inst_eda_check
@@ -43,17 +44,37 @@
   failed_when: false
   when:
     - "'automationedacontroller' in aap_setup_prep_inv_nodes"
+    - aap_setup_down_version is version('2.5', '<')
+    - not aap_setup_inst_force | bool
+
+- name: Check Gateway API Status
+  ansible.builtin.uri:
+    url: https://{{ gateway_hostname }}/api/gateway/v1/status/
+    method: GET
+    user: admin
+    password: "{{ aap_setup_prep_inv_secrets.all.automationgateway_admin_password | default(aap_setup_prep_inv_vars.all.automationgateway_admin_password) }}"
+    validate_certs: "{{ gateway_validate_certs | default('false') }}"
+    force_basic_auth: true
+  register: __aap_setup_inst_gateway_check
+  ignore_errors: true
+  failed_when: false
+  when:
+    - "'automationgateway' in aap_setup_prep_inv_nodes"
+    - aap_setup_down_version is version('2.5', '>=')
     - not aap_setup_inst_force | bool
 
 - name: Install AAP
   when: >
     aap_setup_inst_force
     or ('automationcontroller' in aap_setup_prep_inv_nodes
-        and __aap_setup_inst_ctl_check.status != 200)
+      and (aap_setup_down_version is version('2.5', '>=') |
+      ternary(__aap_setup_inst_gateway_check.json.services.controller.status | default('') != 'good',  __aap_setup_inst_ctl_check.status | default(401) != 200)))
     or ('automationhub' in aap_setup_prep_inv_nodes
-        and __aap_setup_inst_ah_check.status != 200)
+      and (aap_setup_down_version is version('2.5', '>=') |
+      ternary(__aap_setup_inst_gateway_check.json.services.hub.status | default('') != 'good',  __aap_setup_inst_ctl_ah.status | default(401) != 200)))
     or ('automationedacontroller' in aap_setup_prep_inv_nodes
-        and __aap_setup_inst_eda_check.status != 200)
+      and (aap_setup_down_version is version('2.5', '>=') |
+      ternary(__aap_setup_inst_gateway_check.json.services.eda.status | default('') != 'good',  __aap_setup_inst_ctl_eda.status | default(401) != 200)))
   block:
     - name: Copy extra vars files to workspace
       ansible.builtin.copy:
@@ -85,7 +106,9 @@
       until: __aap_setup_inst_result.status == 200
       retries: 90
       delay: 10
-      when: "'automationcontroller' in aap_setup_prep_inv_nodes"
+      when:
+        - "'automationcontroller' in aap_setup_prep_inv_nodes"
+        - aap_setup_down_version is version('2.5', '<')
 
     - name: Wait for automation hub to be running
       ansible.builtin.uri: # use the first host from the list if no hostname is defined
@@ -100,20 +123,87 @@
       until: __aap_setup_inst_result_ah.status == 200
       retries: 90
       delay: 10
-      when: "'automationhub' in aap_setup_prep_inv_nodes"
+      when:
+        - "'automationhub' in aap_setup_prep_inv_nodes"
+        - aap_setup_down_version is version('2.5', '<')
 
     - name: Wait for EDA controller to be running
       ansible.builtin.uri: # use the first host from the list if no hostname is defined
         url: https://{{ eda_hostname }}/
         method: GET
         user: admin
-        password: "{{ aap_setup_prep_inv_secrets.all.automationedacontroller_admin_password | default(aap_setup_prep_inv_vars.all.automationedacontroller_admin_password)
-          }}"
+        password: "{{ aap_setup_prep_inv_secrets.all.automationedacontroller_admin_password | default(aap_setup_prep_inv_vars.all.automationedacontroller_admin_password) }}"
         validate_certs: "{{ eda_validate_certs | default('false') }}"
         force_basic_auth: true
       register: __aap_setup_inst_result_eda
       until: __aap_setup_inst_result_eda.status == 200
       retries: 90
       delay: 10
-      when: "'automationedacontroller' in aap_setup_prep_inv_nodes"
+      when:
+        - "'automationedacontroller' in aap_setup_prep_inv_nodes"
+        - aap_setup_down_version is version('2.5', '<')
+
+    - name: Wait for Automation controller service to be running
+      ansible.builtin.uri: # use the first host from the list if no hostname is defined
+        url: https://{{ gateway_hostname }}/api/gateway/v1/status/
+        method: GET
+        user: admin
+        password: "{{ aap_setup_prep_inv_secrets.all.automationgateway_admin_password | default(aap_setup_prep_inv_vars.all.automationgateway_admin_password) }}"
+        validate_certs: "{{ gateway_validate_certs | default('false') }}"
+        force_basic_auth: true
+      register: __aap_setup_inst_result_gateway
+      until: __aap_setup_inst_result_gateway.json.services.controller.status == "good"
+      retries: 90
+      delay: 10
+      when:
+        - "'automationcontroller' in aap_setup_prep_inv_nodes"
+        - aap_setup_down_version is version('2.5', '>=')
+
+    - name: Wait for Automation Hub service to be running
+      ansible.builtin.uri: # use the first host from the list if no hostname is defined
+        url: https://{{ gateway_hostname }}/api/gateway/v1/status/
+        method: GET
+        user: admin
+        password: "{{ aap_setup_prep_inv_secrets.all.automationgateway_admin_password | default(aap_setup_prep_inv_vars.all.automationgateway_admin_password) }}"
+        validate_certs: "{{ gateway_validate_certs | default('false') }}"
+        force_basic_auth: true
+      register: __aap_setup_inst_result_gateway
+      until: __aap_setup_inst_result_gateway.json.services.hub.status == "good"
+      retries: 90
+      delay: 10
+      when:
+        - "'automationhub' in aap_setup_prep_inv_nodes"
+        - aap_setup_down_version is version('2.5', '>=')
+
+    - name: Wait for EDA controller service to be running
+      ansible.builtin.uri: # use the first host from the list if no hostname is defined
+        url: https://{{ gateway_hostname }}/api/gateway/v1/status/
+        method: GET
+        user: admin
+        password: "{{ aap_setup_prep_inv_secrets.all.automationgateway_admin_password | default(aap_setup_prep_inv_vars.all.automationgateway_admin_password) }}"
+        validate_certs: "{{ gateway_validate_certs | default('false') }}"
+        force_basic_auth: true
+      register: __aap_setup_inst_result_gateway
+      until: __aap_setup_inst_result_gateway.json.services.eda.status == "good"
+      retries: 90
+      delay: 10
+      when:
+        - "'automationedacontroller' in aap_setup_prep_inv_nodes"
+        - aap_setup_down_version is version('2.5', '>=')
+
+    - name: Wait for Automation Gateway service to be running
+      ansible.builtin.uri: # use the first host from the list if no hostname is defined
+        url: https://{{ gateway_hostname }}/api/gateway/v1/status/
+        method: GET
+        user: admin
+        password: "{{ aap_setup_prep_inv_secrets.all.automationgateway_admin_password | default(aap_setup_prep_inv_vars.all.automationgateway_admin_password) }}"
+        validate_certs: "{{ gateway_validate_certs | default('false') }}"
+        force_basic_auth: true
+      register: __aap_setup_inst_result_gateway
+      until: __aap_setup_inst_result_gateway.json.services.gateway.status == "good"
+      retries: 90
+      delay: 10
+      when:
+        - "'automationgateway' in aap_setup_prep_inv_nodes"
+        - aap_setup_down_version is version('2.5', '>=')
 ...


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

This adds support to install the latest AAP 2.5 version. 

# How should this be tested?

Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples)

~~~
aap_setup_down_offline_token: "<token>"
aap_setup_down_version: "2.5"
aap_setup_down_type: "setup"
aap_setup_rhel_version: "9"
aap_setup_prep_inv_nodes:
  automationcontroller:
    controller.example.com:
  database:
    db.example.com:
  automationgateway:
    gateway.example.com:
  automationhub:
    hub.example.com:
  automationedacontroller:
    eda.example.com:
aap_setup_prep_inv_vars:
  automationcontroller:
    node_type: hybrid
    ignore_preflight_errors: true
  automationhub:
    ignore_preflight_errors: true
  automationedacontroller:
    ignore_preflight_errors: true
  automationgateway:
    ignore_preflight_errors: true
  all:
    pg_host: "db.example.com"
    pg_port: "5432"
    pg_database: "awx"
    pg_username: "awx"
    pg_sslmode: "prefer"

    automationhub_pg_host: db.example.com
    automationhub_pg_port: "5432"
    automationhub_pg_database: "automationhub"
    automationhub_pg_username: "automationhub"
    automationhub_pg_sslmode: "prefer"

    automationedacontroller_pg_host: db.example.com
    automationedacontroller_pg_port: "5432"
    automationedacontroller_pg_database: "automationedacontroller"
    automationedacontroller_pg_username: "automationedacontroller"
    automationedacontroller_pg_sslmode: "prefer"

    automationgateway_pg_host: db.example.com
    automationgateway_pg_port: "5432"
    automationgateway_pg_database: "automationgateway"
    automationgateway_pg_username: "automationgateway"
    automationgateway_pg_sslmode: "prefer"

    receptor_listener_port: 27199
aap_setup_prep_inv_secrets:
  all:
    registry_url: "registry.redhat.io"
    registry_username: "<registry_user>"
    registry_password: "<registry_password>"
    admin_password: 'changeme'
    pg_password: 'changeme'
    automationhub_admin_password: 'changeme'
    automationhub_pg_password: 'changeme'
    automationedacontroller_admin_password: 'changeme'
    automationedacontroller_pg_password: 'changeme'
    automationgateway_admin_password: 'changeme'
    automationgateway_pg_password: 'changeme'
aap_setup_inst_extra_vars:
  disable_no_log: true
controller_hostname: "controller.example.com"
controller_validate_certs: false
ah_hostname: "hub.example.com"
ah_validate_certs: false
eda_hostname: "eda.example.com"
eda_validate_certs: false
gateway_hostname: "gateway.example.com"
gateway_validate_certs: false
~~~

# Is there a relevant Issue open for this?

Provide a link to any open issues that describe the problem you are solving.
resolves #[number]

# Other Relevant info, PRs, etc

Please be aware of this Jira [AAP-32816](https://issues.redhat.com/browse/AAP-32816) where the EDA status shows degraded (404 not found on port 8443) when you hit the Gateway API. This causes the `setup.sh` to still execute even though the component is installed correctly. 

To test it properly, after the installation is successful, change the following on EDA Server

~~~
# vi /etc/nginx/conf.d/automation-eda-controller-event-stream.conf 

#location ~ ^/api/eda/v1/external_event_stream/ { ---> comment out this line
location ~ ^/api/eda/ {   ---> add this line
~~~ 

Restart EDA Server

~~~
# automation-eda-controller-service restart
~~~

Now check the Gateway API status 

~~~
# curl -k -u admin:changeme https://gateway.example.com/api/gateway/v1/status/
~~~