### PR TITLE
Parametrize async and poll to tune them as per need

### DIFF
--- a/changelogs/fragments/aap_backup_task.yaml
+++ b/changelogs/fragments/aap_backup_task.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - aap_backup - Updated tasks and default to parametrize async and poll to respect long running backup for AAP2.4+ with private automation hub

--- a/roles/aap_backup/README.md
+++ b/roles/aap_backup/README.md
@@ -13,6 +13,8 @@ Available variables are listed below, along with default values defined (see def
 ```yaml
 aap_setup_prep_setup_dir:  # Must be set, though if the aap_setup_prepare role has been run prior, a fact will be set.
 aap_backup_dest: "/root"
+aap_backup_async: 10000
+aap_backup_poll: 20
 ```
 
 ## Example Playbook

--- a/roles/aap_backup/defaults/main.yml
+++ b/roles/aap_backup/defaults/main.yml
@@ -5,4 +5,6 @@
 
 # Default backup vars, these are default from installer
 aap_backup_dest: /var/tmp
+aap_backup_async: 10000
+aap_backup_poll: 20
 ...

--- a/roles/aap_backup/tasks/backup.yml
+++ b/roles/aap_backup/tasks/backup.yml
@@ -12,7 +12,7 @@
   ansible.builtin.command: ./setup.sh -e 'backup_dest={{ aap_backup_dest | quote }}' -b
   args:
     chdir: "{{ aap_setup_prep_setup_dir }}"
-  async: 10000
-  poll: 20
+  async: "{{ aap_backup_async }}"
+  poll: "{{ aap_backup_poll }}"
   changed_when: false # these will always run and will always report "changed" otherwise
 ...


### PR DESCRIPTION
Parametrize async and poll for long running backup for AAP2.4+ with private automation hub

<!--- markdownlint-disable MD041 -->
# What does this PR do?

* Updated tasks and default to parametrize async and poll to respect long running backup for AAP2.4+ with private automation hub
* Avoid timeout exceeded error on backup task level where task beyond 10000 seconds times out for larger AAP environments.
* Avoid hard coding value and generalize the play.

# How should this be tested?

Provide a value above 10000 seconds to async and poll to test a backup job on AAP.

# Is there a relevant Issue open for this?

A support case is open with Red Hat to troubleshoot this.

# Other Relevant info, PRs, etc

Please provide link to other PRs that may be related (blocking, resolves, etc. etc.)
