### PR TITLE
Add gitleaks config file and update git ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ collections/*
 
 # Ignore test directory
 test
+
+# Ignore installed ansible collections
+/.ansible

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,6 @@
+[allowlist]
+  description = "Global Allowlist"
+  paths = [
+    # Ignore downloaded collections
+    '''(?:^|\/)\.ansible\/collections\/''',
+  ]


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

Adds the `.ansible` directory to the git ignore list. Running `pre-commit` is causing the `.ansible` directory to be created in the current working directory and automated PR creation such as update the pre-commit versions to include it in the git commit.

This caused Red Hat Infosec to raise a security leak as the `kubernetes.core` collection tests include passwords and/or tokens needed for tests.

In addition to adding the `.ansible` directory to the git ignore list this also include a gitleaks configuration file that will cause gitleaks to not raise a security violation for passwords and tokens in the `.ansible/collections` directory. This is being added at the request of the Red Hat Infosec team and the contents of the `.gitleaks.toml` file was provided by them.

# How should this be tested?

N/A

# Is there a relevant Issue open for this?

None

# Other Relevant info, PRs, etc

See PRs #266 and #269 for example of where the `.ansible` directory was included in the automated update to the pre-commit configuration.