### PR TITLE
Corrected lightspeed logic of AnsibleAutomationPlatform resource

### DIFF
--- a/roles/aap_ocp_install/templates/platform/instance.yaml.j2
+++ b/roles/aap_ocp_install/templates/platform/instance.yaml.j2
@@ -54,4 +54,4 @@ spec:
 {% endif %}
 
   lightspeed:
-    disabled: {{ aap_ocp_install_lightspeed is defined and aap_ocp_install_lightspeed['install'] is defined and aap_ocp_install_lightspeed['install'] | bool }}
+    disabled: {{ not (aap_ocp_install_lightspeed is defined and aap_ocp_install_lightspeed['install'] is defined and aap_ocp_install_lightspeed['install'] | bool) }}


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

Correct logic for how `lightspeed` component is managed for `AnsibleAutomationPlatform` resource

# How should this be tested?

Attempt to deploy AAP 2.5 using the default configuration. `lightspeed` component should not be installed and value of `lightspeed` component will be `true`

# Is there a relevant Issue open for this?

#272 
