### PR TITLE
remove liting from galaxy ignore

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -18,8 +18,6 @@ build_ignore:
     - galaxy.yml.j2
     - .github
     - .markdownlint.yml
-    - .ansible-lint
-    - .yamllint.yml
     - .pre-commit-config.yaml
     - .gitignore
     - .gitattributes


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

remove liting from galaxy ignore, is now the norm for galaxy import.

# How should this be tested?

Updates the automated tests.
