### PR TITLE
Updated OpenShift install logic to support manual approval mode

### DIFF
--- a/changelogs/fragments/ocp-olm-manual-approval.yml
+++ b/changelogs/fragments/ocp-olm-manual-approval.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - aap_ocp_install - Enhanced support for manual approval of OLM operators.
+...

--- a/roles/aap_ocp_install/README.md
+++ b/roles/aap_ocp_install/README.md
@@ -53,10 +53,6 @@ The aap_ocp_install_platform and aap_ocp_install_lightspeed Dictionaries are onl
 
 \* If the channel indicates version 2.5 or above of AAP, then the new AAP operator platform installation method will be used.
 
-> ℹ️ **NOTE**
->
-> When `approval` is set to `Manual` the operator will be installed with `Automatic` approval and then after installation the approval will be updated to Manual.
-
 ### aap_ocp_install_controller keys
 
 | Key Name                       | Required | Default Value                           | Description                                                                                                            |

--- a/roles/aap_ocp_install/tasks/install-operator.yml
+++ b/roles/aap_ocp_install/tasks/install-operator.yml
@@ -18,7 +18,7 @@
     resource_definition: "{{ lookup('template', 'operator/subscription.yaml.j2') | from_yaml | ansible.builtin.combine(aap_ocp_install_operator['subscription_manifest_overrides'] | default({}), recursive=true) }}"
     apply: true
 
-- name: Wait for operator installation to complete
+- name: Wait for operator installplan to appear
   kubernetes.core.k8s_info:
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
@@ -28,22 +28,60 @@
     api_version: operators.coreos.com/v1alpha1
     namespace: "{{ aap_ocp_install_namespace | mandatory }}"
   register: __aap_ocp_install_sub_result
-  until: (__aap_ocp_install_sub_result['resources'][0]['status']['state'] is defined) and (__aap_ocp_install_sub_result['resources'][0]['status']['state'] == 'AtLatestKnown')
-  retries: 24
-  delay: 10
+  until:
+    - __aap_ocp_install_sub_result is defined
+    - ('resources' in __aap_ocp_install_sub_result)
+    - __aap_ocp_install_sub_result.resources | length > 0
+    - ('status' in __aap_ocp_install_sub_result.resources[0])
+    - ('installplan' in __aap_ocp_install_sub_result.resources[0].status)
+  retries: 60  # Wait for 15 minutes (60*15/60)
+  delay: 15
 
 - name: Update install plan
-  kubernetes.core.k8s_json_patch:
+  when: (aap_ocp_install_operator['approval'] | default('Automatic') | lower) == 'manual'
+  kubernetes.core.k8s:
+    host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
+    api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
+    validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
+    definition:
+      kind: InstallPlan
+      apiVersion: operators.coreos.com/v1alpha1
+      metadata:
+        namespace: "{{ aap_ocp_install_namespace | mandatory }}"
+        name: "{{ __aap_ocp_install_sub_result.resources[0].status.installplan.name }}"
+      spec:
+        approved: true
+
+- name: Retrieve Installed CSV
+  kubernetes.core.k8s_info:
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
     kind: Subscription
-    namespace: "{{ aap_ocp_install_namespace | mandatory }}"
     name: ansible-automation-platform-operator
     api_version: operators.coreos.com/v1alpha1
-    patch:
-      - op: replace
-        path: /spec/installPlanApproval
-        value: Manual
-  when: (aap_ocp_install_operator['approval'] | default('Automatic') | lower) == 'manual'
+    namespace: "{{ aap_ocp_install_namespace | mandatory }}"
+  register: __aap_ocp_install_sub_approved_result
+  retries: 60  # Wait for 15 minutes (60*15/60)
+  delay: 15
+  until:
+    - __aap_ocp_install_sub_approved_result.resources[0].status.currentCSV is defined
+    - __aap_ocp_install_sub_approved_result.resources[0].status.currentCSV | length > 0
+
+- name: Wait for Operator CSV to be Successful
+  kubernetes.core.k8s_info:
+    host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
+    api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
+    validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
+    kind: ClusterServiceVersion
+    name: "{{ __aap_ocp_install_sub_approved_result.resources[0].status.currentCSV }}"
+    api_version: operators.coreos.com/v1alpha1
+    namespace: "{{ aap_ocp_install_namespace | mandatory }}"
+  register: __aap_ocp_install_csv_result
+  until:
+    - __aap_ocp_install_csv_result.resources[0].status.phase is defined
+    - __aap_ocp_install_csv_result.resources[0].status.phase | length > 0
+    - __aap_ocp_install_csv_result.resources[0].status.phase == "Succeeded"
+  retries: 60  # Wait for 15 minutes (60*15/60)
+  delay: 15
 ...


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

Updates the logic to handle manual approval mode for `aap_ocp_install` role

# How should this be tested?

Invoke the `aap_ocp_install` role with the following variables:

```yaml
aap_ocp_install_connection:
  host: "<OpenShift_Host>"
  api_key: <OpenShift_API_Key>
  validate_certs: false
aap_ocp_install_namespace: aap
aap_ocp_install_controller:
  instance_name: "aap1"
aap_ocp_install_operator:
  channel: 'stable-2.5'
  approval: Manual
  subscription_manifest_overrides:
    spec:
      installPlanApproval: Manual
      startingCSV: aap-operator.v2.5.0-0.1728520175
```

# Is there a relevant Issue open for this?

N/A

# Other Relevant info, PRs, etc

N/A