### PR TITLE
Fixing filename when templating ansible.cfg.j2

### DIFF
--- a/roles/aap_setup_install/tasks/containerized.yml
+++ b/roles/aap_setup_install/tasks/containerized.yml
@@ -66,7 +66,7 @@
       when: aap_setup_inst_log_dir is defined
       ansible.builtin.template:
         src: ansible.cfg.j2
-        dest: "{{ aap_setup_inst_setup_dir }}/ansible.cfg.j2"
+        dest: "{{ aap_setup_inst_setup_dir }}/ansible.cfg"
         mode: "0644"
 
     - name: Run the Ansible Automation Platform setup program


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

This PR fixes the filename of ansible.cfg when generated through  template module when the variable `aap_setup_inst_log_dir` is defined


# Is there a relevant Issue open for this?

resolves #295 

