### PR TITLE
Add /api to controller url in containerized setup install check steps

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -7,7 +7,6 @@
 exclude_paths:
   - .github/
   - changelogs/
-parseable: true
 use_default_rules: true
 # https://github.com/ansible/ansible-lint/issues/808
 #  with verbosity set to 1, its dumping 'unknown file type messages'

--- a/changelogs/fragments/validate-installation.yml
+++ b/changelogs/fragments/validate-installation.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Modify URL used to validate installation

--- a/changelogs/fragments/validate-installation.yml
+++ b/changelogs/fragments/validate-installation.yml
@@ -1,2 +1,4 @@
+---
 minor_changes:
   - Modify URL used to validate installation
+...

--- a/roles/aap_setup_install/tasks/containerized.yml
+++ b/roles/aap_setup_install/tasks/containerized.yml
@@ -1,7 +1,7 @@
 ---
 - name: Check Automation Controller Running
   ansible.builtin.uri:
-    url: https://{{ controller_hostname }}:{{ __aap_setup_inst_controller_port }}/
+    url: https://{{ controller_hostname }}:{{ __aap_setup_inst_controller_port }}/api/
     method: GET
     user: admin
     password: "{{ aap_setup_prep_inv_secrets.all.controller_admin_password | default(aap_setup_prep_inv_vars.all.controller_admin_password) }}"
@@ -80,7 +80,7 @@
 
     - name: Wait for automation controller to be running
       ansible.builtin.uri: # use the first host from the list if no hostname is defined
-        url: https://{{ controller_hostname }}:{{ __aap_setup_inst_controller_port }}/
+        url: https://{{ controller_hostname }}:{{ __aap_setup_inst_controller_port }}/api/
         method: GET
         user: admin
         password: "{{ aap_setup_prep_inv_secrets.all.controller_admin_password | default(aap_setup_prep_inv_vars.all.controller_admin_password) }}"


### PR DESCRIPTION
On the latest containerized version for RHEL 9 (2.6-2), the controller endpoint (`/`) returns a 500 error. The `/api` endpoint is functional.

resolves #303