### PR TITLE
Address changes to Git security model

### DIFF
--- a/changelogs/fragments/init-git-ssh.yml
+++ b/changelogs/fragments/init-git-ssh.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - init bare Git repos without becoming another user to avoid non-root issues
+minor_changes:
+  - overcome Git security feature since 2.35.2 refusing to clone Git repositories from other users

--- a/roles/git_ssh_setup/tasks/git_projects.yml
+++ b/roles/git_ssh_setup/tasks/git_projects.yml
@@ -1,0 +1,34 @@
+---
+
+- name: git_projects | Set full name of project directory
+  ansible.builtin.set_fact:
+    __git_ssh_setup_full_path: "{{ full_projects_dir }}/{{ project_item }}.git"
+
+- name: git_projects | Create empty bare repositories if missing
+  ansible.builtin.command:
+    cmd: git init --bare --shared=group {{ __git_ssh_setup_full_path }} # noqa command-instead-of-module
+    creates: "{{ full_projects_dir }}/{{ project_item }}.git"
+
+- name: git_projects | Change ownership of repositories to '{{ git_server_user }}'
+  ansible.builtin.file:
+    path: "{{ __git_ssh_setup_full_path }}"
+    owner: "{{ git_server_user }}"
+    group: "{{ git_server_user }}"
+    recurse: true
+
+- name: git_projects | Check if repository already in safe repositories
+  ansible.builtin.command:
+    cmd: git config --system --get safe.directory {{ __git_ssh_setup_full_path }} # noqa command-instead-of-module
+  changed_when: false
+  failed_when: __git_ssh_setup_safe_dir.rc > 1
+  register: __git_ssh_setup_safe_dir
+
+- name: git_projects | Add repository to safe repositories if necessary
+  ansible.builtin.command:
+    cmd: git config --system --add safe.directory {{ __git_ssh_setup_full_path }} # noqa command-instead-of-module
+  changed_when: true
+  when:
+    - __git_ssh_setup_safe_dir.rc == 1
+    - __git_ssh_setup_safe_dir.stdout != __git_ssh_setup_full_path
+
+...

--- a/roles/git_ssh_setup/tasks/main.yml
+++ b/roles/git_ssh_setup/tasks/main.yml
@@ -37,15 +37,14 @@
     mode: ug+rwsX
     state: directory
 
-- name: Create empty bare repositories if missing
-  ansible.builtin.command:
-    cmd: git init --bare --shared=group {{ full_projects_dir }}/{{ item }}.git # noqa command-instead-of-module
-    creates: "{{ full_projects_dir }}/{{ item }}.git"
-  become: true
-  become_user: "{{ git_server_user }}"
+- name: Create and setup each Git project
+  ansible.builtin.include_tasks:
+    file: git_projects.yml
   loop: "{{ git_projects }}"
+  loop_control:
+    loop_var: project_item
 
-- name: Create and manage client Git users
+- name: Create and manage each client Git users
   ansible.builtin.include_tasks:
     file: git_users.yml
   loop: "{{ git_client_users }}"
@@ -54,7 +53,7 @@
 
 - name: Debug
   ansible.builtin.debug:
-    msg: >
+    msg: >-
       Git repos can be used with e.g.
-      'git clone {{ git_client_users[0].name }}@{{ ansible_host }}:{{ full_projects_dir }}/{{ git_projects[0] }}.git'
+      'git clone {{ git_client_users[0].name }}@{{ ansible_host }}:{{ full_projects_dir }}/{{ git_projects[0] }}.git'.
 ...


### PR DESCRIPTION


<!--- markdownlint-disable MD041 -->
# What does this PR do?

- init bare Git repos without becoming another user to avoid non-root issues
- overcome Git security feature since 2.35.2 refusing to clone Git repositories from other users

# How should this be tested?

Basically follow the instructions from the linked incident

# Is there a relevant Issue open for this?

Provide a link to any open issues that describe the problem you are solving.
resolves #306 

# Other Relevant info, PRs, etc

n/a
