### PR TITLE
Update .ansible-lint to remove parseable param

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -7,7 +7,6 @@
 exclude_paths:
   - .github/
   - changelogs/
-parseable: true
 use_default_rules: true
 # https://github.com/ansible/ansible-lint/issues/808
 #  with verbosity set to 1, its dumping 'unknown file type messages'


### PR DESCRIPTION
The parameter was removed in the v26.1.0 release of ansible-lint via https://github.com/ansible/ansible-lint/pull/4884

<!--- markdownlint-disable MD041 -->
# What does this PR do?

Remove retired parameter from ansible-lint to ensure workflows continue to run properly.

# How should this be tested?

Automated via GitHub actions

# Is there a relevant Issue open for this?

No

# Other Relevant info, PRs, etc

All existing PRs are blocked pending linter config fix.
