### PR TITLE
Fix issues with ansible-core 2.19+

### DIFF
--- a/changelogs/fragments/fix-ansible-core-strictness.yml
+++ b/changelogs/fragments/fix-ansible-core-strictness.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - Satisfy ansible-core 2.19+ strictness on types for until loop waiting on empty list
+  - Change regex_search to match test in pre-validate tasks

--- a/roles/aap_ocp_install/tasks/install-platform.yml
+++ b/roles/aap_ocp_install/tasks/install-platform.yml
@@ -32,7 +32,7 @@
     api_version: route.openshift.io/v1
     namespace: "{{ aap_ocp_install_platform['namespace'] | default(aap_ocp_install_namespace) | mandatory }}"
   register: __aap_ocp_install_platform_route_result
-  until: __aap_ocp_install_platform_route_result['resources']
+  until: __aap_ocp_install_platform_route_result['resources'] | length > 0
   retries: 60  # Wait for 15 minutes (60*15/60)
   delay: 15
 
@@ -65,7 +65,7 @@
   when:
     - aap_ocp_install_controller is defined and aap_ocp_install_controller['install'] is defined and aap_ocp_install_controller['install']
   register: __aap_ocp_install_controller_route_result
-  until: __aap_ocp_install_controller_route_result['resources']
+  until: __aap_ocp_install_controller_route_result['resources'] | length > 0
   retries: 60  # Wait for 15 minutes (60*15/60)
   delay: 15
 
@@ -101,7 +101,7 @@
   when:
     - aap_ocp_install_eda is defined and aap_ocp_install_eda['install'] is defined and aap_ocp_install_eda['install']
   register: __aap_ocp_install_eda_route_result
-  until: __aap_ocp_install_eda_route_result['resources']
+  until: __aap_ocp_install_eda_route_result['resources'] | length > 0
   retries: 60  # Wait for 15 minutes (60*15/60)
   delay: 15
 
@@ -137,7 +137,7 @@
   when:
     - aap_ocp_install_hub is defined and aap_ocp_install_hub['install'] is defined and aap_ocp_install_hub['install']
   register: __aap_ocp_install_hub_route_result
-  until: __aap_ocp_install_hub_route_result['resources']
+  until: __aap_ocp_install_hub_route_result['resources'] | length > 0
   retries: 60  # Wait for 15 minutes (60*15/60)
   delay: 15
 

--- a/roles/aap_ocp_install/tasks/pre-validate-controller.yml
+++ b/roles/aap_ocp_install/tasks/pre-validate-controller.yml
@@ -32,7 +32,7 @@
     - name: Ensure controller namespace variable is set
       ansible.builtin.assert:
         that:
-          - aap_ocp_install_controller['namespace'] | default("", true) | regex_search('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')
+          - aap_ocp_install_controller['namespace'] | default("", true) is match('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')
         quiet: true
   rescue:
     - name: Update validation errors fact - namespace

--- a/roles/aap_ocp_install/tasks/pre-validate-eda.yml
+++ b/roles/aap_ocp_install/tasks/pre-validate-eda.yml
@@ -18,7 +18,7 @@
     - name: Ensure EDA namespace variable is set
       ansible.builtin.assert:
         that:
-          - aap_ocp_install_eda['namespace'] | default("", true) | regex_search('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')
+          - aap_ocp_install_eda['namespace'] | default("", true) is match('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')
         quiet: true
   rescue:
     - name: Update validation errors fact - namespace

--- a/roles/aap_ocp_install/tasks/pre-validate-platform.yml
+++ b/roles/aap_ocp_install/tasks/pre-validate-platform.yml
@@ -32,7 +32,7 @@
     - name: Ensure platform namespace variable is valid
       ansible.builtin.assert:
         that:
-          - aap_ocp_install_platform['namespace'] | default("", true) | regex_search('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')
+          - aap_ocp_install_platform['namespace'] | default("", true) is match('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')
         quiet: true
   rescue:
     - name: Update validation errors fact - namespace

--- a/roles/aap_ocp_install/tasks/pre-validate.yml
+++ b/roles/aap_ocp_install/tasks/pre-validate.yml
@@ -79,7 +79,7 @@
     - name: Ensure OpenShift namespace variable is set
       ansible.builtin.assert:
         that:
-          - aap_ocp_install_namespace | default("", true) | regex_search('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')
+          - aap_ocp_install_namespace | default("", true) is match('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')
         quiet: true
   rescue:
     - name: Update validation errors fact - namespace


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Fixes issues when using ansible-core 2.19+ in 2 ways:

1. pre-validate.yml was indicating the namespace did not conform to RFC1123, even if it did
2. until loops in install-platform.yml were failing if the returned resources list was empty

Both of these worked fine prior to ansible-core 2.19, but in 2.19 and on, these cause errors because their types are more strictly validated.

# How should this be tested?

Test as normal using ansible-core 2.19 or higher.

# Is there a relevant Issue open for this?

Resolve #310 
