### PR TITLE
Add analyse_receptor_stdout.py script and documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,9 @@ collections/*
 !collections/requirements.yml
 *.tar.gz
 
-# Ignore Vim working files
+# Ignore Vim working and backup files
 .*.swp
+*~
 
 # Ignore test directory
 test
@@ -24,3 +25,7 @@ test
 /.ansible
 /ansible.cfg
 /ansible_collections
+
+# ignore generated documentation
+*.html
+*.pdf

--- a/changelogs/fragments/analyse-receptor-stdout.yml
+++ b/changelogs/fragments/analyse-receptor-stdout.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Add analyse_receptor_stdout.py script and documentation to identify lingering tasks and hosts

--- a/docs/analyse_receptor_stdout.md
+++ b/docs/analyse_receptor_stdout.md
@@ -1,0 +1,73 @@
+# Analyse receptor stdout
+
+## Introduction
+
+The script `analyse_receptor_stdout.py` can be used to detect on which tasks and which hosts a playbook/job might be stuck.
+
+Assume that you have a playbook with thousands of hosts, and potentially `free` strategy.
+It becomes very difficult to identify which host is stuck on which task from the information available in the AAP WebUI.
+
+Luckily, assuming you have access to the OS of the responsible execution host, you can find this information, with the help of the script.
+
+## Instructions
+
+1. Connect to the execution host as the user with which AAP has been installed.
+  We'll assume you're in its home directory and have copied there the script `analyse_receptor_stdout.py`.
+1. Call `journalctl -f -t automation-controller-task` and identify the journal entry with the `task_id` equal to the job ID in the UI, and containing a non-null `work_unit_id`, something like (`aap26.example.com` being your execution node`):
+
+    `Feb 25 08:29:24 aap26.example.com automation-controller-task[2247]: 2026-02-25 08:29:24,085 INFO     [3502db8631534ed9aaf66b31c345ee15] awx.analytics.job_lifecycle job-26 work unit id assigned {"type": "job", "task_id": 26, "state": "work_unit_id_assigned", "work_unit_id": "aap26examplecomNklO1HBi", "task_name": "jt_skip_sleep"}`
+
+1. You can then call the script with `./analyse_receptor_stdout.py ./.local/share/containers/storage/volumes/receptor_data/_data/aap26.example.com/aap26examplecomNklO1HBi/stdout`.
+It will show you one JSON object per task/host lingering, i.e. where the task started but never ended.
+This output is followed by a summary of the number of tasks/hosts impacted like `==> 2 lingering task(s) found`.
+1. If there are too many of those, you can limit the output to a specific task by calling the script again with its UUID, as in `./analyse_receptor_stdout.py .../stdout 8ed877b6-e959-9042-525a-000000000007`.
+1. Once the culprit host and task are identified, it becomes more easily possible to troubleshoot the reason, e.g. on the host itself.
+
+## Notes
+
+1. even if the above instructions are made for AAP 2.6 containerized, the script works similarly since AAP 2.4 as RPM, just with different users and paths (`sudo find / -name stdout 2>/dev/null` can do miracles there).
+1. Receptor's stdout file disappears once the job is finished, so don't forget to save it if you want to analyse it later (or have your customer attach it to a ticket).
+The analysis of the saved `stdout` file can be done on any computer.
+
+## Example
+
+When `27` is the job ID, and `localhost1` the identified culprit host:
+
+```console
+$ journalctl -f -t automation-controller-task
+[...]
+Feb 25 08:58:13 aap26.example.com automation-controller-task[2247]: 2026-02-25 08:58:13,178 INFO     [a3c673a9f7544d7da3684682d38f1c8d] awx.analytics.job_lifecycle job-27 work unit id assigned {"type": "job", "task_id": 27, "state": "work_unit_id_assigned", "work_unit_id": "aap26examplecomcdaQPr3R", "task_name": "jt_skip_sleep"}
+
+$ ./analyse_receptor_stdout.py ./.local/share/containers/storage/volumes/receptor_data/_data/aap26.example.com/aap26examplecomcdaQPr3R/stdout
+{
+  "localhost1/4a6d4f97-0cbc-0ba3-16a6-000000000005": {
+    "uuid": "e1e7ec9d-94ab-4f83-9f75-429572e75e6e",
+    "counter": 5,
+    "stdout": "",
+    "start_line": 5,
+    "end_line": 5,
+    "runner_ident": "27",
+    "event": "runner_on_start",
+    "job_id": 27,
+    "pid": 19,
+    "created": "2026-02-25T08:58:15.154488+00:00",
+    "parent_uuid": "4a6d4f97-0cbc-0ba3-16a6-000000000005",
+    "event_data": {
+      "playbook": "pb_skip_sleep.yml",
+      "playbook_uuid": "823260e5-e598-477d-8f3b-7d95879f9360",
+      "play": "skip or not some sleeping tasks",
+      "play_uuid": "4a6d4f97-0cbc-0ba3-16a6-000000000003",
+      "play_pattern": "all",
+      "task": "sleep 60 seconds unless asked to skip",
+      "task_uuid": "4a6d4f97-0cbc-0ba3-16a6-000000000005",
+      "task_action": "ansible.builtin.command",
+      "resolved_action": "ansible.builtin.command",
+      "task_args": "",
+      "task_path": "/runner/project/pb_skip_sleep.yml:10",
+      "host": "localhost1",
+      "uuid": "e1e7ec9d-94ab-4f83-9f75-429572e75e6e"
+    }
+  }
+}
+==> 1 lingering task(s) found
+```

--- a/scripts/analyse_receptor_stdout.py
+++ b/scripts/analyse_receptor_stdout.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+# Script to analyze an Ansible receptor stdout file, by default in the current
+# directory detecting all hosts never returning from a started task.
+# If TASK_UUID is defined, the validation is limited to this specific task.
+# Usage: analyse_receptor_stdout.py [/var/lib/awx/receptor/.../stdout] [task-uuid]
+
+import json
+import os
+import sys
+
+# input parameters, a bit crude but it works
+STDOUT_FILE = sys.argv[1] if len(sys.argv) > 1 else "stdout"
+TASK_UUID = sys.argv[2] if len(sys.argv) > 2 else None
+
+# start and stop events
+RUNNER_START = {"runner_on_start"}
+RUNNER_STOP = {
+    "runner_on_ok",
+    "runner_on_failed",
+    "runner_on_skipped",
+    "runner_on_unreachable",
+}
+
+
+def get_lingering_runners(stdout_file, task_uuid=None):
+    runners_started = {}
+    if task_uuid:  # we only check this specific task
+        with open(stdout_file, "r") as stdout_fp:
+            for line in stdout_fp:
+                event = json.loads(line)
+                if (
+                    "event" in event
+                    and event["event"] in RUNNER_START
+                    and event["event_data"]["task_uuid"] == task_uuid
+                ):
+                    runners_started[event["event_data"]["host"]] = event
+                elif (
+                    "event" in event
+                    and event["event"] in RUNNER_STOP
+                    and event["event_data"]["task_uuid"] == task_uuid
+                ):
+                    del runners_started[event["event_data"]["host"]]
+    else:  # we check all tasks
+        with open(stdout_file, "r") as stdout_fp:
+            for line in stdout_fp:
+                event = json.loads(line)
+                if "event" in event and event["event"] in RUNNER_START:
+                    key = (
+                        event["event_data"]["host"]
+                        + "/"
+                        + event["event_data"]["task_uuid"]
+                    )
+                    runners_started[key] = event
+                elif "event" in event and event["event"] in RUNNER_STOP:
+                    key = (
+                        event["event_data"]["host"]
+                        + "/"
+                        + event["event_data"]["task_uuid"]
+                    )
+                    del runners_started[key]
+    return runners_started
+
+
+if __name__ == "__main__":
+    if not os.path.isfile(STDOUT_FILE):
+        sys.exit(f"File '{STDOUT_FILE}' doesn't exist or isn't readable")
+    runners_lingering = get_lingering_runners(STDOUT_FILE, TASK_UUID)
+    # print the remaining events without finishing one...
+    print(json.dumps(runners_lingering, indent=2))
+    print("==>", len(runners_lingering.keys()), "lingering task(s) found")


### PR DESCRIPTION


<!--- markdownlint-disable MD041 -->
# What does this PR do?

Useful to identify lingering tasks and hosts
Also added more ignored files

# How should this be tested?

Start your favourite AAP cluster and follow the instructions from the added documentation.
Any job with a lengthy task will do the... job. Even an ad-hoc command task with a `sleep 600` command can be used.

# Is there a relevant Issue open for this?

n/a

# Other Relevant info, PRs, etc

Script was presented in the CoP call on the 11th of Feb.
