### PR TITLE
Fix deprecation warnings and standardize when/until format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,7 @@ repos:
       # Roles will trigger an "unknown file type"
       # https://github.com/ansible/ansible-lint/issues/808
       - id: ansible-lint
+        language_version: python3
         pass_filenames: false
         always_run: true
         entry: ansible-lint

--- a/changelogs/fragments/task_consistency.yml
+++ b/changelogs/fragments/task_consistency.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - Fix ansible-core 2.19 deprecation warnings for OCP install role
+  - Standardize when and until keys in OCP install role
+...

--- a/roles/aap_ocp_install/tasks/finalization.yml
+++ b/roles/aap_ocp_install/tasks/finalization.yml
@@ -1,6 +1,8 @@
 ---
 - name: If login succeeded revoke OpenShift API token
-  when: __aap_ocp_install_auth_results['openshift_auth']['api_key'] is defined and aap_ocp_install_connection['api_key'] is not defined
+  when:
+    - __aap_ocp_install_auth_results['openshift_auth']['api_key'] is defined
+    - aap_ocp_install_connection['api_key'] is not defined
   redhat.openshift.openshift_auth:
     host: "{{ aap_ocp_install_connection['host'] | mandatory }}"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"

--- a/roles/aap_ocp_install/tasks/initialization.yml
+++ b/roles/aap_ocp_install/tasks/initialization.yml
@@ -1,21 +1,23 @@
 ---
 - name: Get OpenShift API token
+  when:
+    - aap_ocp_install_connection['api_key'] is not defined
   redhat.openshift.openshift_auth:
     host: "{{ aap_ocp_install_connection['host'] | mandatory }}"
     username: "{{ aap_ocp_install_connection['username'] | mandatory }}"
     password: "{{ aap_ocp_install_connection['password'] | mandatory }}"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
   register: __aap_ocp_install_auth_results
-  when: aap_ocp_install_connection['api_key'] is not defined
 
 - name: Set authentication for provided API key
+  when:
+    - aap_ocp_install_connection['api_key'] is defined
   ansible.builtin.set_fact:
     __aap_ocp_install_auth_results:
       openshift_auth:
         host: "{{ aap_ocp_install_connection['host'] | mandatory }}"
         api_key: "{{ aap_ocp_install_connection['api_key'] | mandatory }}"
         validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
-  when: aap_ocp_install_connection['api_key'] is defined
 
 - name: Include validate-connection tasks
   ansible.builtin.include_tasks:
@@ -27,7 +29,8 @@
     - always
 
 - name: Create namespace
-  when: aap_ocp_install_create_namespace | default(true) | bool
+  when:
+    - aap_ocp_install_create_namespace | default(true) | bool
   kubernetes.core.k8s:
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"

--- a/roles/aap_ocp_install/tasks/install-controller.yml
+++ b/roles/aap_ocp_install/tasks/install-controller.yml
@@ -1,5 +1,7 @@
 ---
 - name: Create controller namespace
+  when:
+    - aap_ocp_install_controller['namespace'] is defined
   kubernetes.core.k8s:
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
@@ -10,8 +12,6 @@
   vars:
     ns_vars:
       ns_name: "{{ aap_ocp_install_controller['namespace'] }}"
-  when:
-    - aap_ocp_install_controller['namespace'] is defined
 
 - name: Create automation controller instance
   kubernetes.core.k8s:
@@ -32,7 +32,8 @@
     api_version: route.openshift.io/v1
     namespace: "{{ aap_ocp_install_controller['namespace'] | default(aap_ocp_install_namespace) | mandatory }}"
   register: __aap_ocp_install_controller_route_result
-  until: __aap_ocp_install_controller_route_result['resources']
+  until:
+    - __aap_ocp_install_controller_route_result['resources'] | length > 0
   retries: 60 # Wait for 15 minutes (60*15/60)
   delay: 15
 
@@ -48,12 +49,15 @@
     status_code:
       - 200
   register: __aap_ocp_install_controller_available
-  until: (__aap_ocp_install_controller_available['status'] == 200) and ('migrations_notran' not in __aap_ocp_install_controller_available['url'])
+  until:
+    - (__aap_ocp_install_controller_available['status'] == 200)
+    - ('migrations_notran' not in __aap_ocp_install_controller_available['url'])
   retries: 120 # Wait for 30 minutes (120*15/60)
   delay: 15
 
 - name: Create automation controller console link
-  when: aap_ocp_install_controller['create_link'] | default(true)
+  when:
+    - aap_ocp_install_controller['create_link'] | default(true) | bool
   kubernetes.core.k8s:
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"

--- a/roles/aap_ocp_install/tasks/install-eda.yml
+++ b/roles/aap_ocp_install/tasks/install-eda.yml
@@ -1,5 +1,7 @@
 ---
 - name: Create EDA controller namespace
+  when:
+    - aap_ocp_install_eda['namespace'] is defined
   kubernetes.core.k8s:
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
@@ -10,8 +12,6 @@
   vars:
     ns_vars:
       ns_name: "{{ aap_ocp_install_eda['namespace'] }}"
-  when:
-    - aap_ocp_install_eda['namespace'] is defined
 
 - name: Create EDA instance
   kubernetes.core.k8s:
@@ -32,7 +32,8 @@
     api_version: route.openshift.io/v1
     namespace: "{{ aap_ocp_install_eda['namespace'] | default(aap_ocp_install_namespace) }}"
   register: __aap_ocp_install_eda_route_result
-  until: __aap_ocp_install_eda_route_result['resources']
+  until:
+    - __aap_ocp_install_eda_route_result['resources'] | length > 0
   retries: 60 # Wait for 15 minutes (60*15/60)
   delay: 15
 
@@ -48,12 +49,14 @@
     status_code:
       - 200
   register: __aap_ocp_install_eda_available
-  until: __aap_ocp_install_eda_available['status'] == 200
+  until:
+    - __aap_ocp_install_eda_available['status'] == 200
   retries: 120 # Wait for 30 minutes (120*15/60)
   delay: 15
 
 - name: Create EDA console link
-  when: aap_ocp_install_eda['create_link'] | default(true)
+  when:
+    - aap_ocp_install_eda['create_link'] | default(true) | bool
   kubernetes.core.k8s:
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"

--- a/roles/aap_ocp_install/tasks/install-hub.yml
+++ b/roles/aap_ocp_install/tasks/install-hub.yml
@@ -1,5 +1,7 @@
 ---
 - name: Create automation hub namespace
+  when:
+    - aap_ocp_install_hub['namespace'] is defined
   kubernetes.core.k8s:
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
@@ -10,8 +12,6 @@
   vars:
     ns_vars:
       ns_name: "{{ aap_ocp_install_hub['namespace'] }}"
-  when:
-    - aap_ocp_install_hub['namespace'] is defined
 
 - name: Create automation hub instance
   kubernetes.core.k8s:
@@ -32,7 +32,8 @@
     api_version: route.openshift.io/v1
     namespace: "{{ aap_ocp_install_hub['namespace'] | default(aap_ocp_install_namespace) | mandatory }}"
   register: __aap_ocp_install_hub_route_result
-  until: __aap_ocp_install_hub_route_result['resources']
+  until:
+    - __aap_ocp_install_hub_route_result['resources'] | length > 0
   retries: 60 # Wait for 15 minutes (60*15/60)
   delay: 15
 
@@ -48,12 +49,14 @@
     status_code:
       - 200
   register: __aap_ocp_install_hub_available
-  until: __aap_ocp_install_hub_available['status'] == 200
+  until:
+    - __aap_ocp_install_hub_available['status'] == 200
   retries: 120 # Wait for 30 minutes (120*15/60)
   delay: 15
 
 - name: Create automation hub console link
-  when: aap_ocp_install_hub['create_link'] | default(true)
+  when:
+    - aap_ocp_install_hub['create_link'] | default(true) | bool
   kubernetes.core.k8s:
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"

--- a/roles/aap_ocp_install/tasks/install-operator.yml
+++ b/roles/aap_ocp_install/tasks/install-operator.yml
@@ -1,6 +1,7 @@
 ---
 - name: Create operator group
-  when: operatorgroup_create | default(true) | bool
+  when:
+    - operatorgroup_create | default(true) | bool
   kubernetes.core.k8s:
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
@@ -38,7 +39,8 @@
   delay: 15
 
 - name: Update install plan
-  when: (aap_ocp_install_operator['approval'] | default('Automatic') | lower) == 'manual'
+  when:
+    - (aap_ocp_install_operator['approval'] | default('Automatic') | lower) == 'manual'
   kubernetes.core.k8s:
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"

--- a/roles/aap_ocp_install/tasks/install-platform.yml
+++ b/roles/aap_ocp_install/tasks/install-platform.yml
@@ -1,5 +1,7 @@
 ---
 - name: Create platform namespace
+  when:
+    - aap_ocp_install_platform['namespace'] is defined
   kubernetes.core.k8s:
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
@@ -10,8 +12,6 @@
   vars:
     ns_vars:
       ns_name: "{{ aap_ocp_install_platform['namespace'] }}"
-  when:
-    - aap_ocp_install_platform['namespace'] is defined
 
 - name: Create automation platform instance
   kubernetes.core.k8s:
@@ -32,8 +32,9 @@
     api_version: route.openshift.io/v1
     namespace: "{{ aap_ocp_install_platform['namespace'] | default(aap_ocp_install_namespace) | mandatory }}"
   register: __aap_ocp_install_platform_route_result
-  until: __aap_ocp_install_platform_route_result['resources'] | length > 0
-  retries: 60  # Wait for 15 minutes (60*15/60)
+  until:
+    - __aap_ocp_install_platform_route_result['resources'] | length > 0
+  retries: 60 # Wait for 15 minutes (60*15/60)
   delay: 15
 
 - name: Store automation platform route
@@ -48,12 +49,18 @@
     status_code:
       - 200
   register: _aap_ocp_install_platform_available
-  until: (_aap_ocp_install_platform_available['status'] == 200) and ('migrations_notran' not in _aap_ocp_install_platform_available['url'])
-  retries: 120  # Wait for 30 minutes (120*15/60)
+  until:
+    - _aap_ocp_install_platform_available['status'] == 200
+    - ('migrations_notran' not in _aap_ocp_install_platform_available['url'])
+  retries: 120 # Wait for 30 minutes (120*15/60)
   delay: 15
 
 # Ensure that all of the platform components are also available
 - name: Wait for operator to create the automation controller route
+  when:
+    - aap_ocp_install_controller is defined
+    - aap_ocp_install_controller['install'] is defined
+    - aap_ocp_install_controller['install'] | bool
   kubernetes.core.k8s_info:
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
@@ -62,34 +69,43 @@
     name: "{{ aap_ocp_install_platform['instance_name'] | mandatory }}-controller"
     api_version: route.openshift.io/v1
     namespace: "{{ aap_ocp_install_platform['namespace'] | default(aap_ocp_install_namespace) | mandatory }}"
-  when:
-    - aap_ocp_install_controller is defined and aap_ocp_install_controller['install'] is defined and aap_ocp_install_controller['install']
   register: __aap_ocp_install_controller_route_result
-  until: __aap_ocp_install_controller_route_result['resources'] | length > 0
-  retries: 60  # Wait for 15 minutes (60*15/60)
+  until:
+    - __aap_ocp_install_controller_route_result['resources'] | length > 0
+  retries: 60 # Wait for 15 minutes (60*15/60)
   delay: 15
 
 - name: Store automation controller route
+  when:
+    - aap_ocp_install_controller is defined
+    - aap_ocp_install_controller['install'] is defined
+    - aap_ocp_install_controller['install'] | bool
   ansible.builtin.set_fact:
     aap_ocp_install_controller_route: "https://{{ __aap_ocp_install_controller_route_result['resources'][0]['status']['ingress'][0]['host'] }}"
-  when:
-    - aap_ocp_install_controller is defined and aap_ocp_install_controller['install'] is defined and aap_ocp_install_controller['install']
 
 - name: Ensure automation controller API is available
+  when:
+    - aap_ocp_install_controller is defined
+    - aap_ocp_install_controller['install'] is defined
+    - aap_ocp_install_controller['install'] | bool
   ansible.builtin.uri:
     url: "{{ aap_ocp_install_controller_route }}/api"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
     method: GET
     status_code:
       - 200
-  when:
-    - aap_ocp_install_controller is defined and aap_ocp_install_controller['install'] is defined and aap_ocp_install_controller['install']
   register: _aap_ocp_install_controller_available
-  until: (_aap_ocp_install_controller_available['status'] == 200) and ('migrations_notran' not in _aap_ocp_install_controller_available['url'])
-  retries: 120  # Wait for 30 minutes (120*15/60)
+  until:
+    - (_aap_ocp_install_controller_available['status'] == 200)
+    - ('migrations_notran' not in _aap_ocp_install_controller_available['url'])
+  retries: 120 # Wait for 30 minutes (120*15/60)
   delay: 15
 
 - name: Wait for operator to create the automation EDA route
+  when:
+    - aap_ocp_install_eda is defined
+    - aap_ocp_install_eda['install'] is defined
+    - aap_ocp_install_eda['install'] | bool
   kubernetes.core.k8s_info:
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
@@ -98,34 +114,43 @@
     name: "{{ aap_ocp_install_platform['instance_name'] | mandatory }}-eda"
     api_version: route.openshift.io/v1
     namespace: "{{ aap_ocp_install_platform['namespace'] | default(aap_ocp_install_namespace) | mandatory }}"
-  when:
-    - aap_ocp_install_eda is defined and aap_ocp_install_eda['install'] is defined and aap_ocp_install_eda['install']
   register: __aap_ocp_install_eda_route_result
-  until: __aap_ocp_install_eda_route_result['resources'] | length > 0
-  retries: 60  # Wait for 15 minutes (60*15/60)
+  until:
+    - __aap_ocp_install_eda_route_result['resources'] | length > 0
+  retries: 60 # Wait for 15 minutes (60*15/60)
   delay: 15
 
 - name: Store automation eda route
+  when:
+    - aap_ocp_install_eda is defined
+    - aap_ocp_install_eda['install'] is defined
+    - aap_ocp_install_eda['install'] | bool
   ansible.builtin.set_fact:
     aap_ocp_install_eda_route: "https://{{ __aap_ocp_install_eda_route_result['resources'][0]['status']['ingress'][0]['host'] }}"
-  when:
-    - aap_ocp_install_eda is defined and aap_ocp_install_eda['install'] is defined and aap_ocp_install_eda['install']
 
 - name: Ensure automation eda API is available
+  when:
+    - aap_ocp_install_eda is defined
+    - aap_ocp_install_eda['install'] is defined
+    - aap_ocp_install_eda['install'] | bool
   ansible.builtin.uri:
     url: "{{ aap_ocp_install_eda_route }}/api"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
     method: GET
     status_code:
       - 200
-  when:
-    - aap_ocp_install_eda is defined and aap_ocp_install_eda['install'] is defined and aap_ocp_install_eda['install']
   register: _aap_ocp_install_eda_available
-  until: (_aap_ocp_install_eda_available['status'] == 200) and ('migrations_notran' not in _aap_ocp_install_eda_available['url'])
-  retries: 120  # Wait for 30 minutes (120*15/60)
+  until:
+    - (_aap_ocp_install_eda_available['status'] == 200)
+    - ('migrations_notran' not in _aap_ocp_install_eda_available['url'])
+  retries: 120 # Wait for 30 minutes (120*15/60)
   delay: 15
 
 - name: Wait for operator to create the automation hub route
+  when:
+    - aap_ocp_install_hub is defined
+    - aap_ocp_install_hub['install'] is defined
+    - aap_ocp_install_hub['install'] | bool
   kubernetes.core.k8s_info:
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
@@ -134,35 +159,41 @@
     name: "{{ aap_ocp_install_platform['instance_name'] | mandatory }}-hub"
     api_version: route.openshift.io/v1
     namespace: "{{ aap_ocp_install_platform['namespace'] | default(aap_ocp_install_namespace) | mandatory }}"
-  when:
-    - aap_ocp_install_hub is defined and aap_ocp_install_hub['install'] is defined and aap_ocp_install_hub['install']
   register: __aap_ocp_install_hub_route_result
-  until: __aap_ocp_install_hub_route_result['resources'] | length > 0
-  retries: 60  # Wait for 15 minutes (60*15/60)
+  until:
+    - __aap_ocp_install_hub_route_result['resources'] | length > 0
+  retries: 60 # Wait for 15 minutes (60*15/60)
   delay: 15
 
 - name: Store automation hub route
+  when:
+    - aap_ocp_install_hub is defined
+    - aap_ocp_install_hub['install'] is defined
+    - aap_ocp_install_hub['install'] | bool
   ansible.builtin.set_fact:
     aap_ocp_install_hub_route: "https://{{ __aap_ocp_install_hub_route_result['resources'][0]['status']['ingress'][0]['host'] }}"
-  when:
-    - aap_ocp_install_hub is defined and aap_ocp_install_hub['install'] is defined and aap_ocp_install_hub['install']
 
 - name: Ensure automation hub API is available
+  when:
+    - aap_ocp_install_hub is defined
+    - aap_ocp_install_hub['install'] is defined
+    - aap_ocp_install_hub['install'] | bool
   ansible.builtin.uri:
     url: "{{ aap_ocp_install_hub_route }}/api/galaxy/pulp/api/v3/"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
     method: GET
     status_code:
       - 200
-  when:
-    - aap_ocp_install_hub is defined and aap_ocp_install_hub['install'] is defined and aap_ocp_install_hub['install']
   register: _aap_ocp_install_hub_available
-  until: (_aap_ocp_install_hub_available['status'] == 200) and ('migrations_notran' not in _aap_ocp_install_hub_available['url'])
-  retries: 120  # Wait for 30 minutes (120*15/60)
+  until:
+    - (_aap_ocp_install_hub_available['status'] == 200)
+    - ('migrations_notran' not in _aap_ocp_install_hub_available['url'])
+  retries: 120 # Wait for 30 minutes (120*15/60)
   delay: 15
 
 - name: Create automation platform console link
-  when: aap_ocp_install_platform['create_link'] | default(true)
+  when:
+    - aap_ocp_install_platform['create_link'] | default(true) | bool
   kubernetes.core.k8s:
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"

--- a/roles/aap_ocp_install/tasks/main.yml
+++ b/roles/aap_ocp_install/tasks/main.yml
@@ -20,52 +20,61 @@
         - always
 
     - name: Include Ansible Automation Platform operator install tasks
+      when:
+        - aap_ocp_install_operator is defined
       ansible.builtin.include_tasks:
         file: install-operator.yml
         apply:
           tags:
             - operator
-      when: aap_ocp_install_operator is defined
       tags:
         - operator
 
     - name: Include Ansible Automation Platform platform install tasks
+      when:
+        - aap_ocp_install_platform is defined
+        - __aap_ocp_install_25_install | bool
       ansible.builtin.include_tasks:
         file: install-platform.yml
         apply:
           tags:
             - platform
-      when: aap_ocp_install_platform is defined and __aap_ocp_install_25_install
       tags:
         - platform
 
     - name: Include Ansible Automation Platform controller install tasks
+      when:
+        - aap_ocp_install_controller is defined
+        - not __aap_ocp_install_25_install | bool
       ansible.builtin.include_tasks:
         file: install-controller.yml
         apply:
           tags:
             - controller
-      when: aap_ocp_install_controller is defined and not __aap_ocp_install_25_install
       tags:
         - controller
 
     - name: Include Ansible Automation Platform hub install tasks
+      when:
+        - aap_ocp_install_hub is defined
+        - not __aap_ocp_install_25_install | bool
       ansible.builtin.include_tasks:
         file: install-hub.yml
         apply:
           tags:
             - hub
-      when: aap_ocp_install_hub is defined and not __aap_ocp_install_25_install
       tags:
         - hub
 
     - name: Include Ansible Automation Platform EDA install tasks
+      when:
+        - aap_ocp_install_eda is defined
+        - not __aap_ocp_install_25_install | bool
       ansible.builtin.include_tasks:
         file: install-eda.yml
         apply:
           tags:
             - eda
-      when: aap_ocp_install_eda is defined and not __aap_ocp_install_25_install
       tags:
         - eda
 

--- a/roles/aap_ocp_install/tasks/pre-validate-controller.yml
+++ b/roles/aap_ocp_install/tasks/pre-validate-controller.yml
@@ -13,7 +13,8 @@
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_controller['instance_name'] must be set"] }}
 
 - name: Ensure controller admin username variable is set (block)
-  when: aap_ocp_install_controller['admin_user'] is defined
+  when:
+    - aap_ocp_install_controller['admin_user'] is defined
   block:
     - name: Ensure controller admin username variable is set
       ansible.builtin.assert:
@@ -27,7 +28,8 @@
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_controller['admin_user'] must be a non-empty string"] }}
 
 - name: Ensure controller namespace variable is set (block)
-  when: aap_ocp_install_controller['namespace'] is defined
+  when:
+    - aap_ocp_install_controller['namespace'] is defined
   block:
     - name: Ensure controller namespace variable is set
       ansible.builtin.assert:
@@ -42,7 +44,8 @@
           characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'"] }}
 
 - name: Ensure controller link text variable is set (block)
-  when: aap_ocp_install_controller['link_text'] is defined
+  when:
+    - aap_ocp_install_controller['link_text'] is defined
   block:
     - name: Ensure controller link text variable is set
       ansible.builtin.assert:
@@ -56,7 +59,8 @@
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_controller['link_text'] must be a non-empty string"] }}
 
 - name: Ensure controller image pull policy is valid (block)
-  when: aap_ocp_install_controller['image_pull_policy'] is defined
+  when:
+    - aap_ocp_install_controller['image_pull_policy'] is defined
   block:
     - name: Ensure controller image pull policy is valid
       ansible.builtin.assert:
@@ -70,7 +74,8 @@
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_controller['image_pull_policy'] must be one of: IfNotPresent, Always, or Never"] }}
 
 - name: Ensure controller create preload data is valid (block)
-  when: aap_ocp_install_controller['create_preload_data'] is defined
+  when:
+    - aap_ocp_install_controller['create_preload_data'] is defined
   block:
     - name: Ensure controller create preload data is valid
       ansible.builtin.assert:
@@ -84,7 +89,8 @@
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_controller['create_preload_data'] must be one of: true or false"] }}
 
 - name: Ensure controller garbage collect secrets is valid (block)
-  when: aap_ocp_install_controller['garbage_collect_secrets'] is defined
+  when:
+    - aap_ocp_install_controller['garbage_collect_secrets'] is defined
   block:
     - name: Ensure controller garbage collect secrets is valid
       ansible.builtin.assert:
@@ -98,7 +104,8 @@
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_controller['garbage_collect_secrets'] must be one of: true or false"] }}
 
 - name: Ensure controller projects persistence is valid (block)
-  when: aap_ocp_install_controller['projects_persistence'] is defined
+  when:
+    - aap_ocp_install_controller['projects_persistence'] is defined
   block:
     - name: Ensure controller projects persistence is valid
       ansible.builtin.assert:
@@ -112,7 +119,8 @@
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_controller['projects_persistence'] must be one of: true or false"] }}
 
 - name: Ensure controller replicas is valid (block)
-  when: aap_ocp_install_controller['replicas'] is defined
+  when:
+    - aap_ocp_install_controller['replicas'] is defined
   block:
     - name: Ensure controller replicas is valid
       ansible.builtin.assert:
@@ -126,13 +134,13 @@
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_controller['replicas'] must be a number greater than 0"] }}
 
 - name: Ensure controller projects storage size is valid (block)
-  when: aap_ocp_install_controller['projects_storage_size'] is defined
+  when:
+    - aap_ocp_install_controller['projects_storage_size'] is defined
   block:
     - name: Ensure controller projects storage size is valid
       ansible.builtin.assert:
         that:
-          - (aap_ocp_install_controller['projects_storage_size'] | regex_replace('^(?P<size>[0-9]+)(?P<si>Ki|K|Mi|M|Gi|G|Ti|T|Pi|P|Ei|E)$', '\\g<size>') | int) >
-            0
+          - (aap_ocp_install_controller['projects_storage_size'] | regex_replace('^(?P<size>[0-9]+)(?P<si>Ki|K|Mi|M|Gi|G|Ti|T|Pi|P|Ei|E)$', '\\g<size>') | int) > 0
           - (aap_ocp_install_controller['projects_storage_size'] | regex_replace('^(?P<size>[0-9]+)(?P<si>Ki|K|Mi|M|Gi|G|Ti|T|Pi|P|Ei|E)$', '\\g<si>')) is in ['Ki','K','Mi','M','Gi','G','Ti','T','Pi','P','Ei','E']
         quiet: true
   rescue:

--- a/roles/aap_ocp_install/tasks/pre-validate-eda.yml
+++ b/roles/aap_ocp_install/tasks/pre-validate-eda.yml
@@ -13,7 +13,8 @@
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_eda['instance_name'] must be set"] }}
 
 - name: Ensure EDA namespace variable is set (block)
-  when: aap_ocp_install_eda['namespace'] is defined
+  when:
+    - aap_ocp_install_eda['namespace'] is defined
   block:
     - name: Ensure EDA namespace variable is set
       ansible.builtin.assert:
@@ -28,7 +29,8 @@
           or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'"] }}
 
 - name: Ensure EDA link text variable is set (block)
-  when: aap_ocp_install_eda['link_text'] is defined
+  when:
+    - aap_ocp_install_eda['link_text'] is defined
   block:
     - name: Ensure EDA link text variable is set
       ansible.builtin.assert:
@@ -42,7 +44,8 @@
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_eda['link_text'] must be a non-empty string"] }}
 
 - name: Ensure EDA replicas is valid (block)
-  when: aap_ocp_install_eda['replicas'] is defined
+  when:
+    - aap_ocp_install_eda['replicas'] is defined
   block:
     - name: Ensure EDA replicas is valid
       ansible.builtin.assert:

--- a/roles/aap_ocp_install/tasks/pre-validate-platform.yml
+++ b/roles/aap_ocp_install/tasks/pre-validate-platform.yml
@@ -13,7 +13,8 @@
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_platform['instance_name'] must be set"] }}
 
 - name: Ensure controller admin username variable is set (block)
-  when: aap_ocp_install_controller['admin_user'] is defined
+  when:
+    - aap_ocp_install_controller['admin_user'] is defined
   block:
     - name: Ensure controller admin username variable is set
       ansible.builtin.assert:
@@ -27,7 +28,8 @@
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_controller['admin_user'] must be a non-empty string"] }}
 
 - name: Ensure platform namespace variable is valid if set (block)
-  when: aap_ocp_install_platform['namespace'] is defined
+  when:
+    - aap_ocp_install_platform['namespace'] is defined
   block:
     - name: Ensure platform namespace variable is valid
       ansible.builtin.assert:
@@ -41,7 +43,8 @@
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_platform['namespace'] must be a lowercase RFC 1123 label consisting of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'"] }}
 
 - name: Ensure platform link text variable is valid if set (block)
-  when: aap_ocp_install_platform['link_text'] is defined
+  when:
+    - aap_ocp_install_platform['link_text'] is defined
   block:
     - name: Ensure platform link text variable is set
       ansible.builtin.assert:
@@ -55,7 +58,8 @@
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_platform['link_text'] must be a non-empty string"] }}
 
 - name: Ensure controller image pull policy is valid (block)
-  when: aap_ocp_install_controller['image_pull_policy'] is defined
+  when:
+    - aap_ocp_install_controller['image_pull_policy'] is defined
   block:
     - name: Ensure controller image pull policy is valid
       ansible.builtin.assert:
@@ -69,7 +73,8 @@
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_controller['image_pull_policy'] must be one of: IfNotPresent, Always, or Never"] }}
 
 - name: Ensure controller create preload data is valid (block)
-  when: aap_ocp_install_controller['create_preload_data'] is defined
+  when:
+    - aap_ocp_install_controller['create_preload_data'] is defined
   block:
     - name: Ensure controller create preload data is valid
       ansible.builtin.assert:
@@ -83,7 +88,8 @@
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_controller['create_preload_data'] must be one of: true or false"] }}
 
 - name: Ensure controller garbage collect secrets is valid (block)
-  when: aap_ocp_install_controller['garbage_collect_secrets'] is defined
+  when:
+    - aap_ocp_install_controller['garbage_collect_secrets'] is defined
   block:
     - name: Ensure controller garbage collect secrets is valid
       ansible.builtin.assert:
@@ -97,7 +103,8 @@
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_controller['garbage_collect_secrets'] must be one of: true or false"] }}
 
 - name: Ensure controller projects persistence is valid (block)
-  when: aap_ocp_install_controller['projects_persistence'] is defined
+  when:
+    - aap_ocp_install_controller['projects_persistence'] is defined
   block:
     - name: Ensure controller projects persistence is valid
       ansible.builtin.assert:
@@ -111,7 +118,8 @@
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_controller['projects_persistence'] must be one of: true or false"] }}
 
 - name: Ensure controller replicas is valid (block)
-  when: aap_ocp_install_controller['replicas'] is defined
+  when:
+    - aap_ocp_install_controller['replicas'] is defined
   block:
     - name: Ensure controller replicas is valid
       ansible.builtin.assert:
@@ -125,7 +133,8 @@
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_controller['replicas'] must be a number greater than 0"] }}
 
 - name: Ensure controller projects storage size is valid (block)
-  when: aap_ocp_install_controller['projects_storage_size'] is defined
+  when:
+    - aap_ocp_install_controller['projects_storage_size'] is defined
   block:
     - name: Ensure controller projects storage size is valid
       ansible.builtin.assert:
@@ -140,7 +149,9 @@
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_controller['projects_storage_size'] must be a number greater than 0 with a size (e.g. 12Gi or 10000M)"] }}
 
 - name: Ensure hub storage type is valid (block)
-  when: aap_ocp_install_hub is defined and aap_ocp_install_hub['storage_type'] is defined
+  when:
+    - aap_ocp_install_hub is defined
+    - aap_ocp_install_hub['storage_type'] is defined
   block:
     - name: Ensure hub storage type is valid
       ansible.builtin.assert:
@@ -154,7 +165,9 @@
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_hub['storage_type'] must be 'file', 'S3' or 'azure'"] }}
 
 - name: Ensure hub file storage settings are valid (block)
-  when: aap_ocp_install_hub['storage_type'] is defined and aap_ocp_install_hub['storage_type'] == 'file'
+  when:
+    - aap_ocp_install_hub['storage_type'] is defined
+    - aap_ocp_install_hub['storage_type'] == 'file'
   block:
     - name: Ensure hub file storage settings are valid
       ansible.builtin.assert:
@@ -169,7 +182,9 @@
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_hub['file_storage_size'] must be a number greater than 0 with a size (e.g. 12Gi or 10000M)"] }}
 
 - name: Ensure hub S3 storage settings are valid (block)
-  when: aap_ocp_install_hub['storage_type'] is defined and aap_ocp_install_hub['storage_type'] == 'S3'
+  when:
+    - aap_ocp_install_hub['storage_type'] is defined
+    - aap_ocp_install_hub['storage_type'] == 'S3'
   block:
     - name: Ensure hub S3 storage settings are valid
       ansible.builtin.assert:
@@ -183,7 +198,9 @@
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_hub['object_storage_s3_secret'] must be the name of a valid S3 storage secret name"] }}
 
 - name: Ensure hub Azure storage settings are valid (block)
-  when: aap_ocp_install_hub['storage_type'] is defined and aap_ocp_install_hub['storage_type'] == 'azure'
+  when:
+    - aap_ocp_install_hub['storage_type'] is defined
+    - aap_ocp_install_hub['storage_type'] == 'azure'
   block:
     - name: Ensure hub Azure storage settings are valid
       ansible.builtin.assert:

--- a/roles/aap_ocp_install/tasks/pre-validate.yml
+++ b/roles/aap_ocp_install/tasks/pre-validate.yml
@@ -14,7 +14,8 @@
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_connection['host'] must be set"] }}
 
 - name: Ensure OpenShift username and password variables are not set when API Token set (block)
-  when: aap_ocp_install_connection['api_key'] is defined
+  when:
+    - aap_ocp_install_connection['api_key'] is defined
   block:
     - name: Ensure OpenShift username and password variables are not set when API Token set
       ansible.builtin.assert:
@@ -30,7 +31,8 @@
           is set"] }}
 
 - name: Ensure OpenShift API token variable is set (block)
-  when: aap_ocp_install_connection['api_key'] is defined
+  when:
+    - aap_ocp_install_connection['api_key'] is defined
   block:
     - name: Ensure OpenShift API token variable is set
       ansible.builtin.assert:
@@ -45,7 +47,8 @@
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_connection['api_key'] must be set"] }}
 
 - name: Ensure OpenShift username variable is set (block)
-  when: aap_ocp_install_connection['api_key'] is not defined
+  when:
+    - aap_ocp_install_connection['api_key'] is not defined
   block:
     - name: Ensure OpenShift username variable is set
       ansible.builtin.assert:
@@ -60,7 +63,8 @@
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_connection['username'] must be set"] }}
 
 - name: Ensure OpenShift password variable is set (block)
-  when: aap_ocp_install_connection['api_key'] is not defined
+  when:
+    - aap_ocp_install_connection['api_key'] is not defined
   block:
     - name: Ensure OpenShift password variable is set
       ansible.builtin.assert:
@@ -79,7 +83,7 @@
     - name: Ensure OpenShift namespace variable is set
       ansible.builtin.assert:
         that:
-          - aap_ocp_install_namespace | default("", true) is match('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')
+          - (aap_ocp_install_namespace | default("", true) | regex_search('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')) is not none
         quiet: true
   rescue:
     - name: Update validation errors fact - namespace
@@ -89,10 +93,10 @@
           or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'"] }}
 
 - name: Ensure operator variables are set
-  ansible.builtin.include_tasks:
-    file: pre-validate-operator.yml
   when:
     - ( 'operator' in ansible_run_tags ) or ( 'all' in ansible_run_tags and aap_ocp_install_operator is defined )
+  ansible.builtin.include_tasks:
+    file: pre-validate-operator.yml
 
 - name: Retrieve the requested operator channel version numbers
   ansible.builtin.set_fact:
@@ -109,28 +113,32 @@
                                   and (__aap_ocp_install_minor_version | int) >= 5) }}"
 
 - name: Ensure platform variables are set
+  when:
+    - (( 'platform' in ansible_run_tags ) or ( 'all' in ansible_run_tags and aap_ocp_install_platform is defined ))
+    - (__aap_ocp_install_25_install | bool)
   ansible.builtin.include_tasks:
     file: pre-validate-platform.yml
-  when:
-    - (( 'platform' in ansible_run_tags ) or ( 'all' in ansible_run_tags and aap_ocp_install_platform is defined )) and __aap_ocp_install_25_install
 
 - name: Ensure controller variables are set
+  when:
+    - (( 'controller' in ansible_run_tags ) or ( 'all' in ansible_run_tags and aap_ocp_install_controller is defined ))
+    - not (__aap_ocp_install_25_install | bool)
   ansible.builtin.include_tasks:
     file: pre-validate-controller.yml
-  when:
-    - (( 'controller' in ansible_run_tags ) or ( 'all' in ansible_run_tags and aap_ocp_install_controller is defined )) and not __aap_ocp_install_25_install
 
 - name: Ensure hub variables are set
+  when:
+    - (( 'hub' in ansible_run_tags ) or ( 'all' in ansible_run_tags and aap_ocp_install_hub is defined ))
+    - not (__aap_ocp_install_25_install | bool)
   ansible.builtin.include_tasks:
     file: pre-validate-hub.yml
-  when:
-    - (( 'hub' in ansible_run_tags ) or ( 'all' in ansible_run_tags and aap_ocp_install_hub is defined )) and not __aap_ocp_install_25_install
 
 - name: Ensure eda variables are set
+  when:
+    - (( 'eda' in ansible_run_tags ) or ( 'all' in ansible_run_tags and aap_ocp_install_eda is defined ))
+    - not (__aap_ocp_install_25_install | bool)
   ansible.builtin.include_tasks:
     file: pre-validate-eda.yml
-  when:
-    - (( 'eda' in ansible_run_tags ) or ( 'all' in ansible_run_tags and aap_ocp_install_eda is defined )) and not __aap_ocp_install_25_install
 
 - name: Ensure no validation errors found
   ansible.builtin.debug:
@@ -138,5 +146,4 @@
       - "The following errors must be fixed to continue:"
       - "{{ __aap_ocp_install_prevalidate_errors }}"
   failed_when: (__aap_ocp_install_prevalidate_errors | length) > 0
-  when: (__aap_ocp_install_prevalidate_errors | length) > 0
 ...


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

This PR is focused on the `aap_ocp_install` role Updates when clauses so that they always return True or False in support of the changes to ansible-core 2.19 and beyond. This also standardizes all of the when and until clauses to use list style syntax and ensures consistent placement of the `when` keys on a task.

# How should this be tested?

Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples)

# Is there a relevant Issue open for this?

No

# Other Relevant info, PRs, etc

N/A