### PR TITLE
Add consistent tasks names prefix

### DIFF
--- a/changelogs/fragments/add-consistent-prefix.yml
+++ b/changelogs/fragments/add-consistent-prefix.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Add consistently prefix to name of tasks in non-main tasks files as per good practices

--- a/roles/aap_backup/tasks/backup.yml
+++ b/roles/aap_backup/tasks/backup.yml
@@ -1,13 +1,13 @@
 ---
 # Create directory
-- name: Create backup directory
+- name: backup | Create backup directory
   ansible.builtin.file:
     state: directory
     path: "{{ aap_backup_dest }}"
     mode: '0750'
 
 # Run the Setup to backup AAP
-- name: Run the Ansible AAP Setup Program with backup option
+- name: backup | Run the Ansible AAP Setup Program with backup option
   become: true
   ansible.builtin.command: ./setup.sh -e 'backup_dest={{ aap_backup_dest | quote }}' -b
   args:

--- a/roles/aap_certs/tasks/autohub.yml
+++ b/roles/aap_certs/tasks/autohub.yml
@@ -1,7 +1,7 @@
 ---
 # according to https://access.redhat.com/solutions/5731261
 
-- name: Autohub | get certificate file content
+- name: autohub | Get certificate file content
   when:
     - aap_certs_autohub_ssl_cert is defined
     - aap_certs_autohub_ssl_key is defined
@@ -9,7 +9,7 @@
     aap_certs_autohub_ssl_cert_content: "{{ lookup('ansible.builtin.file', aap_certs_autohub_ssl_cert) }}"
     aap_certs_autohub_ssl_key_content: "{{ lookup('ansible.builtin.file', aap_certs_autohub_ssl_key) }}"
 
-- name: Autohub | update certificate file
+- name: autohub | Update certificate file
   become: true
   ansible.builtin.template:
     src: cert_content.j2
@@ -22,7 +22,7 @@
   vars:
     file_content: "{{ aap_certs_autohub_ssl_cert_content }}"
 
-- name: Autohub | update certificate key file
+- name: autohub | Update certificate key file
   become: true
   ansible.builtin.template:
     src: cert_content.j2

--- a/roles/aap_certs/tasks/controller.yml
+++ b/roles/aap_certs/tasks/controller.yml
@@ -1,7 +1,7 @@
 ---
 # according to https://access.redhat.com/solutions/3109871
 
-- name: Controller | get certificate file content
+- name: controller | Get certificate file content
   when:
     - aap_certs_controller_ssl_cert is defined
     - aap_certs_controller_ssl_key is defined
@@ -9,7 +9,7 @@
     aap_certs_controller_ssl_cert_content: "{{ lookup('ansible.builtin.file', aap_certs_controller_ssl_cert) }}"
     aap_certs_controller_ssl_key_content: "{{ lookup('ansible.builtin.file', aap_certs_controller_ssl_key) }}"
 
-- name: Controller | update certificate file
+- name: controller | Update certificate file
   become: true
   ansible.builtin.template:
     src: cert_content.j2
@@ -22,7 +22,7 @@
   vars:
     file_content: "{{ aap_certs_controller_ssl_cert_content }}"
 
-- name: Controller | update certificate key file
+- name: controller | Update certificate key file
   become: true
   ansible.builtin.template:
     src: cert_content.j2

--- a/roles/aap_certs/tasks/edacontroller.yml
+++ b/roles/aap_certs/tasks/edacontroller.yml
@@ -1,5 +1,5 @@
 ---
-- name: EDA Controller | get certificate file content
+- name: edacontroller | Get certificate file content
   when:
     - aap_certs_eda_ssl_cert is defined
     - aap_certs_eda_ssl_key is defined
@@ -7,7 +7,7 @@
     aap_certs_eda_ssl_cert_content: "{{ lookup('ansible.builtin.file', aap_certs_eda_ssl_cert) }}"
     aap_certs_eda_ssl_key_content: "{{ lookup('ansible.builtin.file', aap_certs_eda_ssl_key) }}"
 
-- name: EDA Controller | update certificate file
+- name: edacontroller | Update certificate file
   become: true
   ansible.builtin.template:
     src: cert_content.j2
@@ -20,7 +20,7 @@
   vars:
     file_content: "{{ aap_certs_eda_ssl_cert_content }}"
 
-- name: EDA Controller | update certificate key file
+- name: edacontroller | Update certificate key file
   become: true
   ansible.builtin.template:
     src: cert_content.j2

--- a/roles/aap_manage_containerized_services/tasks/aap_restart.yml
+++ b/roles/aap_manage_containerized_services/tasks/aap_restart.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Restart PostgreSQL Service
+- name: aap_restart | Restart PostgreSQL Service
   ansible.builtin.systemd_service:
     name: postgresql
     state: restarted
@@ -8,7 +8,7 @@
   when: inventory_hostname in groups['database']
   tags: postgres
 
-- name: Restart Receptor Services
+- name: aap_restart | Restart Receptor Services
   ansible, builtin. systemd_service:
     name: receptor
     state: restarted
@@ -17,7 +17,7 @@
     or ('execution nodes' in groups and inventory_hostname in groups['execution_nodes'])
   tags: receptor
 
-- name: Restart Redis (Unix) Services
+- name: aap_restart | Restart Redis (Unix) Services
   ansible.builtin.systemd_service:
     name: redis-unix
     state: restarted
@@ -26,7 +26,7 @@
     or inventory_hostname in groups['automationcontroller']
   tags: redisunix
 
-- name: Restart Redis (TCP) Services
+- name: aap_restart | Restart Redis (TCP) Services
   ansible.builtin.systemd_service:
     name: redis-tcp
     state: restarted
@@ -34,7 +34,7 @@
   when: "'redis' in groups and inventory_hostname in groups['redis']"
   tags: redistp
 
-- name: Restart Automation Hub Services
+- name: aap_restart | Restart Automation Hub Services
   ansible.builtin.systemd_service:
     name: "{{ item }}"
     state: restarted
@@ -43,7 +43,7 @@
   when: inventory_hostname in groups['automationhub']
   tags: hub
 
-- name: Restart Automation Controller Services
+- name: aap_restart | Restart Automation Controller Services
   ansible.builtin.systemd_service:
     name: "{{ item }}"
     state: restarted
@@ -52,7 +52,7 @@
   when: inventory_hostname in groups['automationcontroller']
   tags: controller
 
-- name: Restart Automation EDA Services
+- name: aap_restart | Restart Automation EDA Services
   ansible.builtin.systemd_service:
     name: "{{ item }}"
     state: restarted
@@ -61,7 +61,7 @@
   when: inventory _hostname in groups['automationeda']
   tags: eda
 
-- name: Restart Automation Gateway
+- name: aap_restart | Restart Automation Gateway
   ansible.builtin.systemd_service:
     name: "{{ item }}"
     state: restarted

--- a/roles/aap_manage_containerized_services/tasks/aap_start.yml
+++ b/roles/aap_manage_containerized_services/tasks/aap_start.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Start PostgreSQL Service
+- name: aap_start | Start PostgreSQL Service
   ansible.builtin.systemd_service:
     name: postgresql
     state: started
@@ -8,7 +8,7 @@
   when: inventory_hostname in groups['database']
   tags: postgres
 
-- name: Start Receptor Services
+- name: aap_start | Start Receptor Services
   ansible, builtin. systemd_service:
     name: receptor
     state: started
@@ -17,7 +17,7 @@
     or ('execution nodes' in groups and inventory_hostname in groups['execution_nodes'])
   tags: receptor
 
-- name: Start Redis (Unix) Services
+- name: aap_start | Start Redis (Unix) Services
   ansible.builtin.systemd_service:
     name: redis-unix
     state: started
@@ -26,7 +26,7 @@
     or inventory_hostname in groups['automationcontroller']
   tags: redisunix
 
-- name: Start Redis (TCP) Services
+- name: aap_start | Start Redis (TCP) Services
   ansible.builtin.systemd_service:
     name: redis-tcp
     state: started
@@ -34,7 +34,7 @@
   when: "'redis' in groups and inventory_hostname in groups['redis']"
   tags: redistcp
 
-- name: Start Automation Hub Services
+- name: aap_start | Start Automation Hub Services
   ansible.builtin.systemd_service:
     name: "{{ item }}"
     state: started
@@ -43,7 +43,7 @@
   when: inventory_hostname in groups['automationhub']
   tags: hub
 
-- name: Start Automation Controller Services
+- name: aap_start | Start Automation Controller Services
   ansible.builtin.systemd_service:
     name: "{{ item }}"
     state: started
@@ -52,7 +52,7 @@
   when: inventory_hostname in groups['automationcontroller']
   tags: controller
 
-- name: Start Automation EDA Services
+- name: aap_start | Start Automation EDA Services
   ansible.builtin.systemd_service:
     name: "{{ item }}"
     state: started
@@ -61,7 +61,7 @@
   when: inventory _hostname in groups['automationeda']
   tags: eda
 
-- name: Start Automation Gateway
+- name: aap_start | Start Automation Gateway
   ansible.builtin.systemd_service:
     name: "{{ item }}"
     state: started

--- a/roles/aap_manage_containerized_services/tasks/aap_status.yml
+++ b/roles/aap_manage_containerized_services/tasks/aap_status.yml
@@ -1,37 +1,37 @@
 ---
 
-- name: Get Automation Gateway Services Status
+- name: aap_status | Get Automation Gateway Services Status
   ansible.builtin.include_tasks: aap_status_tasks.yml
   loop: "{{ gateway_services }}"
   when: inventory_hostname in groups[' automationgateway']
   tags: gateway
 
-- name: Get Automation EDA Services Status
+- name: aap_status | Get Automation EDA Services Status
   ansible.builtin.include_tasks: aap_status_tasks.yml
   loop: "{{ eda_services }}"
   when: inventory_hostname in groups['automationeda']
   tags: eda
 
-- name: Get Automation Controller Services Status
+- name: aap_status | Get Automation Controller Services Status
   ansible.builtin.include_tasks: aap_status_tasks.yml
   loop: "{{ controller_services }}"
   when: inventory_hostname in groups['automationcontroller']
   tags: controller
 
-- name: Get Automation Hub Services Status
+- name: aap_status | Get Automation Hub Services Status
   ansible.builtin.include_tasks: aap_status_tasks.yml
   loop: "{f hub_services }}"
   when: inventory_hostname in groups['automationhub']
   tags: hub
 
-- name: Get Redis (TCP) Service Status
+- name: aap_status | Get Redis (TCP) Service Status
   ansible.builtin.include_tasks: aap_status_tasks.yml
   vars:
     item: redis-tcp
   when: "'redis' in groups and inventory_hostname in groups['redis']"
   tags: redistcp
 
-- name: Get Redis (Unix) Service Status
+- name: aap_status | Get Redis (Unix) Service Status
   ansible.builtin.include_tasks: aap_status_tasks.yml
   vars:
     item: redis-unix
@@ -39,7 +39,7 @@
     or inventory_hostname in groups['automationhub']
   tags: redisunix
 
-- name: Get Receptor Service Status
+- name: aap_status | Get Receptor Service Status
   ansible.builtin.include_tasks: aap_status_tasks.yml
   vars:
     item: receptor
@@ -47,7 +47,7 @@
     or ('execution_nodes' in groups and inventory_hostname in groups['execution_nodes'])
   tags: receptor
 
-- name: Get PostgreSQL Service Status
+- name: aap_status | Get PostgreSQL Service Status
   ansible.builtin.include_tasks: aap_status_tasks.yml
   vars:
     item: postgresq

--- a/roles/aap_manage_containerized_services/tasks/aap_status_tasks.yml
+++ b/roles/aap_manage_containerized_services/tasks/aap_status_tasks.yml
@@ -1,12 +1,12 @@
 ---
 
-- name: Get the status for {{ item }}
+- name: aap_status_tasks | Get the status for {{ item }}
   ansible.builtin.systemd_service:
     name: "{{ item }}"
     scope: user
   register: svc_state
 
-- name: Print the status for {{ item }}
+- name: aap_status_tasks | Print the status for {{ item }}
   ansible.builtin.debug:
     msg: "{{ item }} state is {{ svc_state.status.SubState }}"
 

--- a/roles/aap_manage_containerized_services/tasks/aap_stop.yml
+++ b/roles/aap_manage_containerized_services/tasks/aap_stop.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Stop Automation Gateway
+- name: aap_stop | Stop Automation Gateway
   ansible.builtin.systemd_service:
     name: "{{ item }}"
     state: stopped
@@ -9,7 +9,7 @@
   when: inventory_hostname in groups['automationgateway']
   tags: gateway
 
-- name: Stop Automation EDA Services
+- name: aap_stop | Stop Automation EDA Services
   ansible.builtin.systemd_service:
     name: "{{ item }}"
     state: stopped
@@ -18,7 +18,7 @@
   when: inventory_hostname in groups['automationeda']
   tags: eda
 
-- name: Stop Automation Controller Services
+- name: aap_stop | Stop Automation Controller Services
   ansible.builtin.systemd_service:
     name: "{{ item }}"
     state: stopped
@@ -27,7 +27,7 @@
   when: inventory_hostname in groups['automationcontroller']
   tags: controller
 
-- name: Stop Automation Hub Services
+- name: aap_stop | Stop Automation Hub Services
   ansible.builtin.systemd_service:
     name: "{{ item }}"
     state: stopped
@@ -36,7 +36,7 @@
   when: inventory_hostname in groups['automationhub']
   tags: hub
 
-- name: Stop Redis (TCP) Services
+- name: aap_stop | Stop Redis (TCP) Services
   ansible.builtin.systemd_service:
     name: redis-tcp
     state: stopped
@@ -44,7 +44,7 @@
   when: "'redis' in groups and inventory_hostname in groups ['redis']"
   tags: redistcp
 
-- name: Stop Redis (Unix) Services
+- name: aap_stop | Stop Redis (Unix) Services
   ansible. builtin. systemd_service:
     name: redis-unix
     state: stopped
@@ -53,7 +53,7 @@
     or inventory_hostname in groups['automationcontroller']
   tags: redisunix
 
-- name: Stop Receptor Services
+- name: aap_stop | Stop Receptor Services
   ansible.builtin.systemd_service:
     name: receptor
     state: stopped
@@ -62,7 +62,7 @@
     or ('execution_nodes' in groups and inventory_hostname in groups['execution_nodes'])
   tags: receptor
 
-- name: Stop PostgreSQL Service
+- name: aap_stop | Stop PostgreSQL Service
   ansible.builtin.systemd_service:
     name: postgresql
     state: stopped

--- a/roles/aap_ocp_install/tasks/finalization.yml
+++ b/roles/aap_ocp_install/tasks/finalization.yml
@@ -1,5 +1,5 @@
 ---
-- name: If login succeeded revoke OpenShift API token
+- name: finalization | If login succeeded revoke OpenShift API token
   when:
     - __aap_ocp_install_auth_results['openshift_auth']['api_key'] is defined
     - aap_ocp_install_connection['api_key'] is not defined

--- a/roles/aap_ocp_install/tasks/initialization.yml
+++ b/roles/aap_ocp_install/tasks/initialization.yml
@@ -1,5 +1,5 @@
 ---
-- name: Get OpenShift API token
+- name: initialization | Get OpenShift API token
   when:
     - aap_ocp_install_connection['api_key'] is not defined
   redhat.openshift.openshift_auth:
@@ -9,7 +9,7 @@
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
   register: __aap_ocp_install_auth_results
 
-- name: Set authentication for provided API key
+- name: initialization | Set authentication for provided API key
   when:
     - aap_ocp_install_connection['api_key'] is defined
   ansible.builtin.set_fact:
@@ -19,7 +19,7 @@
         api_key: "{{ aap_ocp_install_connection['api_key'] | mandatory }}"
         validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
 
-- name: Include validate-connection tasks
+- name: initialization | Include validate-connection tasks
   ansible.builtin.include_tasks:
     file: validate-connection.yml
     apply:
@@ -28,7 +28,7 @@
   tags:
     - always
 
-- name: Create namespace
+- name: initialization | Create namespace
   when:
     - aap_ocp_install_create_namespace | default(true) | bool
   kubernetes.core.k8s:

--- a/roles/aap_ocp_install/tasks/install-controller.yml
+++ b/roles/aap_ocp_install/tasks/install-controller.yml
@@ -1,5 +1,5 @@
 ---
-- name: Create controller namespace
+- name: install-controller | Create controller namespace
   when:
     - aap_ocp_install_controller['namespace'] is defined
   kubernetes.core.k8s:
@@ -13,7 +13,7 @@
     ns_vars:
       ns_name: "{{ aap_ocp_install_controller['namespace'] }}"
 
-- name: Create automation controller instance
+- name: install-controller | Create automation controller instance
   kubernetes.core.k8s:
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
@@ -22,7 +22,7 @@
     resource_definition: "{{ lookup('template', 'controller/instance.yaml.j2') | from_yaml | ansible.builtin.combine(aap_ocp_install_controller['controller_manifest_overrides'] | default({}), recursive=true) }}"
     apply: true
 
-- name: Wait for operator to create the automation controller route
+- name: install-controller | Wait for operator to create the automation controller route
   kubernetes.core.k8s_info:
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
@@ -37,11 +37,11 @@
   retries: 60 # Wait for 15 minutes (60*15/60)
   delay: 15
 
-- name: Store automation controller route
+- name: install-controller | Store automation controller route
   ansible.builtin.set_fact:
     aap_ocp_install_controller_route: "https://{{ __aap_ocp_install_controller_route_result['resources'][0]['status']['ingress'][0]['host'] }}"
 
-- name: Ensure automation controller login is available
+- name: install-controller | Ensure automation controller login is available
   ansible.builtin.uri:
     url: "{{ aap_ocp_install_controller_route }}"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
@@ -55,7 +55,7 @@
   retries: 120 # Wait for 30 minutes (120*15/60)
   delay: 15
 
-- name: Create automation controller console link
+- name: install-controller | Create automation controller console link
   when:
     - aap_ocp_install_controller['create_link'] | default(true) | bool
   kubernetes.core.k8s:

--- a/roles/aap_ocp_install/tasks/install-eda.yml
+++ b/roles/aap_ocp_install/tasks/install-eda.yml
@@ -1,5 +1,5 @@
 ---
-- name: Create EDA controller namespace
+- name: install-eda | Create EDA controller namespace
   when:
     - aap_ocp_install_eda['namespace'] is defined
   kubernetes.core.k8s:
@@ -13,7 +13,7 @@
     ns_vars:
       ns_name: "{{ aap_ocp_install_eda['namespace'] }}"
 
-- name: Create EDA instance
+- name: install-eda | Create EDA instance
   kubernetes.core.k8s:
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
@@ -22,7 +22,7 @@
     resource_definition: "{{ lookup('template', 'eda/instance.yaml.j2') | from_yaml | ansible.builtin.combine(aap_ocp_install_eda['eda_manifest_overrides'] | default({}), recursive=true) }}"
     apply: true
 
-- name: Wait for operator to create the EDA route
+- name: install-eda | Wait for operator to create the EDA route
   kubernetes.core.k8s_info:
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
@@ -37,11 +37,11 @@
   retries: 60 # Wait for 15 minutes (60*15/60)
   delay: 15
 
-- name: Store EDA route
+- name: install-eda | Store EDA route
   ansible.builtin.set_fact:
     aap_ocp_install_eda_route: "https://{{ __aap_ocp_install_eda_route_result['resources'][0]['status']['ingress'][0]['host'] }}"
 
-- name: Ensure EDA login is available
+- name: install-eda | Ensure EDA login is available
   ansible.builtin.uri:
     url: "{{ aap_ocp_install_eda_route }}"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
@@ -54,7 +54,7 @@
   retries: 120 # Wait for 30 minutes (120*15/60)
   delay: 15
 
-- name: Create EDA console link
+- name: install-eda | Create EDA console link
   when:
     - aap_ocp_install_eda['create_link'] | default(true) | bool
   kubernetes.core.k8s:

--- a/roles/aap_ocp_install/tasks/install-hub.yml
+++ b/roles/aap_ocp_install/tasks/install-hub.yml
@@ -1,5 +1,5 @@
 ---
-- name: Create automation hub namespace
+- name: install-hub | Create automation hub namespace
   when:
     - aap_ocp_install_hub['namespace'] is defined
   kubernetes.core.k8s:
@@ -13,7 +13,7 @@
     ns_vars:
       ns_name: "{{ aap_ocp_install_hub['namespace'] }}"
 
-- name: Create automation hub instance
+- name: install-hub | Create automation hub instance
   kubernetes.core.k8s:
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
@@ -22,7 +22,7 @@
     resource_definition: "{{ lookup('template', 'hub/instance.yaml.j2') | from_yaml | ansible.builtin.combine(aap_ocp_install_hub['hub_manifest_overrides'] | default({}), recursive=true) }}"
     apply: true
 
-- name: Wait for operator to create the automation hub route
+- name: install-hub | Wait for operator to create the automation hub route
   kubernetes.core.k8s_info:
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
@@ -37,11 +37,11 @@
   retries: 60 # Wait for 15 minutes (60*15/60)
   delay: 15
 
-- name: Store automation hub route
+- name: install-hub | Store automation hub route
   ansible.builtin.set_fact:
     aap_ocp_install_hub_route: "https://{{ __aap_ocp_install_hub_route_result['resources'][0]['status']['ingress'][0]['host'] }}"
 
-- name: Ensure automation hub login is available
+- name: install-hub | Ensure automation hub login is available
   ansible.builtin.uri:
     url: "{{ aap_ocp_install_hub_route }}"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
@@ -54,7 +54,7 @@
   retries: 120 # Wait for 30 minutes (120*15/60)
   delay: 15
 
-- name: Create automation hub console link
+- name: install-hub | Create automation hub console link
   when:
     - aap_ocp_install_hub['create_link'] | default(true) | bool
   kubernetes.core.k8s:

--- a/roles/aap_ocp_install/tasks/install-operator.yml
+++ b/roles/aap_ocp_install/tasks/install-operator.yml
@@ -1,5 +1,5 @@
 ---
-- name: Create operator group
+- name: install-operator | Create operator group
   when:
     - operatorgroup_create | default(true) | bool
   kubernetes.core.k8s:
@@ -10,7 +10,7 @@
     resource_definition: "{{ lookup('template', 'operator/operatorgroup.yaml.j2') | from_yaml | ansible.builtin.combine(aap_ocp_install_operator['operatorgroup_manifest_overrides'] | default({}), recursive=true) }}"
     apply: true
 
-- name: Create subscription
+- name: install-operator | Create subscription
   kubernetes.core.k8s:
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
@@ -19,7 +19,7 @@
     resource_definition: "{{ lookup('template', 'operator/subscription.yaml.j2') | from_yaml | ansible.builtin.combine(aap_ocp_install_operator['subscription_manifest_overrides'] | default({}), recursive=true) }}"
     apply: true
 
-- name: Wait for operator installplan to appear
+- name: install-operator | Wait for operator installplan to appear
   kubernetes.core.k8s_info:
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
@@ -38,7 +38,7 @@
   retries: 60  # Wait for 15 minutes (60*15/60)
   delay: 15
 
-- name: Update install plan
+- name: install-operator | Update install plan
   when:
     - (aap_ocp_install_operator['approval'] | default('Automatic') | lower) == 'manual'
   kubernetes.core.k8s:
@@ -54,7 +54,7 @@
       spec:
         approved: true
 
-- name: Retrieve Installed CSV
+- name: install-operator | Retrieve Installed CSV
   kubernetes.core.k8s_info:
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
@@ -70,7 +70,7 @@
     - __aap_ocp_install_sub_approved_result.resources[0].status.currentCSV is defined
     - __aap_ocp_install_sub_approved_result.resources[0].status.currentCSV | length > 0
 
-- name: Wait for Operator CSV to be Successful
+- name: install-operator | Wait for Operator CSV to be Successful
   kubernetes.core.k8s_info:
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"

--- a/roles/aap_ocp_install/tasks/install-platform.yml
+++ b/roles/aap_ocp_install/tasks/install-platform.yml
@@ -1,5 +1,5 @@
 ---
-- name: Create platform namespace
+- name: install-platform | Create platform namespace
   when:
     - aap_ocp_install_platform['namespace'] is defined
   kubernetes.core.k8s:
@@ -13,7 +13,7 @@
     ns_vars:
       ns_name: "{{ aap_ocp_install_platform['namespace'] }}"
 
-- name: Create automation platform instance
+- name: install-platform | Create automation platform instance
   kubernetes.core.k8s:
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
@@ -22,7 +22,7 @@
     resource_definition: "{{ lookup('template', 'platform/instance.yaml.j2') | from_yaml }}"
     apply: true
 
-- name: Wait for operator to create the automation platform route
+- name: install-platform | Wait for operator to create the automation platform route
   kubernetes.core.k8s_info:
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
@@ -37,11 +37,11 @@
   retries: 60 # Wait for 15 minutes (60*15/60)
   delay: 15
 
-- name: Store automation platform route
+- name: install-platform | Store automation platform route
   ansible.builtin.set_fact:
     aap_ocp_install_platform_route: "https://{{ __aap_ocp_install_platform_route_result['resources'][0]['status']['ingress'][0]['host'] }}"
 
-- name: Ensure automation platform login is available
+- name: install-platform | Ensure automation platform login is available
   ansible.builtin.uri:
     url: "{{ aap_ocp_install_platform_route }}"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
@@ -56,7 +56,7 @@
   delay: 15
 
 # Ensure that all of the platform components are also available
-- name: Wait for operator to create the automation controller route
+- name: install-platform | Wait for operator to create the automation controller route
   when:
     - aap_ocp_install_controller is defined
     - aap_ocp_install_controller['install'] is defined
@@ -75,7 +75,7 @@
   retries: 60 # Wait for 15 minutes (60*15/60)
   delay: 15
 
-- name: Store automation controller route
+- name: install-platform | Store automation controller route
   when:
     - aap_ocp_install_controller is defined
     - aap_ocp_install_controller['install'] is defined
@@ -83,7 +83,7 @@
   ansible.builtin.set_fact:
     aap_ocp_install_controller_route: "https://{{ __aap_ocp_install_controller_route_result['resources'][0]['status']['ingress'][0]['host'] }}"
 
-- name: Ensure automation controller API is available
+- name: install-platform | Ensure automation controller API is available
   when:
     - aap_ocp_install_controller is defined
     - aap_ocp_install_controller['install'] is defined
@@ -101,7 +101,7 @@
   retries: 120 # Wait for 30 minutes (120*15/60)
   delay: 15
 
-- name: Wait for operator to create the automation EDA route
+- name: install-platform | Wait for operator to create the automation EDA route
   when:
     - aap_ocp_install_eda is defined
     - aap_ocp_install_eda['install'] is defined
@@ -120,7 +120,7 @@
   retries: 60 # Wait for 15 minutes (60*15/60)
   delay: 15
 
-- name: Store automation eda route
+- name: install-platform | Store automation eda route
   when:
     - aap_ocp_install_eda is defined
     - aap_ocp_install_eda['install'] is defined
@@ -128,7 +128,7 @@
   ansible.builtin.set_fact:
     aap_ocp_install_eda_route: "https://{{ __aap_ocp_install_eda_route_result['resources'][0]['status']['ingress'][0]['host'] }}"
 
-- name: Ensure automation eda API is available
+- name: install-platform | Ensure automation eda API is available
   when:
     - aap_ocp_install_eda is defined
     - aap_ocp_install_eda['install'] is defined
@@ -146,7 +146,7 @@
   retries: 120 # Wait for 30 minutes (120*15/60)
   delay: 15
 
-- name: Wait for operator to create the automation hub route
+- name: install-platform | Wait for operator to create the automation hub route
   when:
     - aap_ocp_install_hub is defined
     - aap_ocp_install_hub['install'] is defined
@@ -165,7 +165,7 @@
   retries: 60 # Wait for 15 minutes (60*15/60)
   delay: 15
 
-- name: Store automation hub route
+- name: install-platform | Store automation hub route
   when:
     - aap_ocp_install_hub is defined
     - aap_ocp_install_hub['install'] is defined
@@ -173,7 +173,7 @@
   ansible.builtin.set_fact:
     aap_ocp_install_hub_route: "https://{{ __aap_ocp_install_hub_route_result['resources'][0]['status']['ingress'][0]['host'] }}"
 
-- name: Ensure automation hub API is available
+- name: install-platform | Ensure automation hub API is available
   when:
     - aap_ocp_install_hub is defined
     - aap_ocp_install_hub['install'] is defined
@@ -191,7 +191,7 @@
   retries: 120 # Wait for 30 minutes (120*15/60)
   delay: 15
 
-- name: Create automation platform console link
+- name: install-platform | Create automation platform console link
   when:
     - aap_ocp_install_platform['create_link'] | default(true) | bool
   kubernetes.core.k8s:

--- a/roles/aap_ocp_install/tasks/pre-validate-controller.yml
+++ b/roles/aap_ocp_install/tasks/pre-validate-controller.yml
@@ -1,150 +1,150 @@
 ---
-- name: Ensure controller instance name variable is set (block)
+- name: pre-validate-controller | Ensure controller instance name variable is set (block)
   block:
-    - name: Ensure controller instance name variable is set
+    - name: pre-validate-controller | Ensure controller instance name variable is set
       ansible.builtin.assert:
         that:
           - aap_ocp_install_controller['instance_name'] | default('', true) | length > 0
         quiet: true
   rescue:
-    - name: Update validation errors fact - controller instance_name
+    - name: pre-validate-controller | Update validation errors fact - controller instance_name
       ansible.builtin.set_fact:
         __aap_ocp_install_prevalidate_errors: >
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_controller['instance_name'] must be set"] }}
 
-- name: Ensure controller admin username variable is set (block)
+- name: pre-validate-controller | Ensure controller admin username variable is set (block)
   when:
     - aap_ocp_install_controller['admin_user'] is defined
   block:
-    - name: Ensure controller admin username variable is set
+    - name: pre-validate-controller | Ensure controller admin username variable is set
       ansible.builtin.assert:
         that:
           - aap_ocp_install_controller['admin_user'] | default('', true) | length > 0
         quiet: true
   rescue:
-    - name: Update validation errors fact - controller admin_user
+    - name: pre-validate-controller | Update validation errors fact - controller admin_user
       ansible.builtin.set_fact:
         __aap_ocp_install_prevalidate_errors: >
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_controller['admin_user'] must be a non-empty string"] }}
 
-- name: Ensure controller namespace variable is set (block)
+- name: pre-validate-controller | Ensure controller namespace variable is set (block)
   when:
     - aap_ocp_install_controller['namespace'] is defined
   block:
-    - name: Ensure controller namespace variable is set
+    - name: pre-validate-controller | Ensure controller namespace variable is set
       ansible.builtin.assert:
         that:
           - aap_ocp_install_controller['namespace'] | default("", true) is match('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')
         quiet: true
   rescue:
-    - name: Update validation errors fact - namespace
+    - name: pre-validate-controller | Update validation errors fact - namespace
       ansible.builtin.set_fact:
         __aap_ocp_install_prevalidate_errors: >
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_controller['namespace'] must be a lowercase RFC 1123 label consisting of lower case alphanumeric
           characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'"] }}
 
-- name: Ensure controller link text variable is set (block)
+- name: pre-validate-controller | Ensure controller link text variable is set (block)
   when:
     - aap_ocp_install_controller['link_text'] is defined
   block:
-    - name: Ensure controller link text variable is set
+    - name: pre-validate-controller | Ensure controller link text variable is set
       ansible.builtin.assert:
         that:
           - aap_ocp_install_controller['link_text'] | default('', true) | length > 0
         quiet: true
   rescue:
-    - name: Update validation errors fact - controller link_text
+    - name: pre-validate-controller | Update validation errors fact - controller link_text
       ansible.builtin.set_fact:
         __aap_ocp_install_prevalidate_errors: >
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_controller['link_text'] must be a non-empty string"] }}
 
-- name: Ensure controller image pull policy is valid (block)
+- name: pre-validate-controller | Ensure controller image pull policy is valid (block)
   when:
     - aap_ocp_install_controller['image_pull_policy'] is defined
   block:
-    - name: Ensure controller image pull policy is valid
+    - name: pre-validate-controller | Ensure controller image pull policy is valid
       ansible.builtin.assert:
         that:
           - aap_ocp_install_controller['image_pull_policy'] is in ['IfNotPresent', 'Always', 'Never']
         quiet: true
   rescue:
-    - name: Update validation errors fact - controller image_pull_policy
+    - name: pre-validate-controller | Update validation errors fact - controller image_pull_policy
       ansible.builtin.set_fact:
         __aap_ocp_install_prevalidate_errors: >
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_controller['image_pull_policy'] must be one of: IfNotPresent, Always, or Never"] }}
 
-- name: Ensure controller create preload data is valid (block)
+- name: pre-validate-controller | Ensure controller create preload data is valid (block)
   when:
     - aap_ocp_install_controller['create_preload_data'] is defined
   block:
-    - name: Ensure controller create preload data is valid
+    - name: pre-validate-controller | Ensure controller create preload data is valid
       ansible.builtin.assert:
         that:
           - (aap_ocp_install_controller['create_preload_data'] | string | lower) is in ['true', 'false']
         quiet: true
   rescue:
-    - name: Update validation errors fact - controller create_preload_data
+    - name: pre-validate-controller | Update validation errors fact - controller create_preload_data
       ansible.builtin.set_fact:
         __aap_ocp_install_prevalidate_errors: >
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_controller['create_preload_data'] must be one of: true or false"] }}
 
-- name: Ensure controller garbage collect secrets is valid (block)
+- name: pre-validate-controller | Ensure controller garbage collect secrets is valid (block)
   when:
     - aap_ocp_install_controller['garbage_collect_secrets'] is defined
   block:
-    - name: Ensure controller garbage collect secrets is valid
+    - name: pre-validate-controller | Ensure controller garbage collect secrets is valid
       ansible.builtin.assert:
         that:
           - (aap_ocp_install_controller['garbage_collect_secrets'] | string | lower) is in ['true', 'false']
         quiet: true
   rescue:
-    - name: Update validation errors fact - controller garbage_collect_secrets
+    - name: pre-validate-controller | Update validation errors fact - controller garbage_collect_secrets
       ansible.builtin.set_fact:
         __aap_ocp_install_prevalidate_errors: >
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_controller['garbage_collect_secrets'] must be one of: true or false"] }}
 
-- name: Ensure controller projects persistence is valid (block)
+- name: pre-validate-controller | Ensure controller projects persistence is valid (block)
   when:
     - aap_ocp_install_controller['projects_persistence'] is defined
   block:
-    - name: Ensure controller projects persistence is valid
+    - name: pre-validate-controller | Ensure controller projects persistence is valid
       ansible.builtin.assert:
         that:
           - (aap_ocp_install_controller['projects_persistence'] | string | lower) is in ['true', 'false']
         quiet: true
   rescue:
-    - name: Update validation errors fact - controller projects_persistence
+    - name: pre-validate-controller | Update validation errors fact - controller projects_persistence
       ansible.builtin.set_fact:
         __aap_ocp_install_prevalidate_errors: >
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_controller['projects_persistence'] must be one of: true or false"] }}
 
-- name: Ensure controller replicas is valid (block)
+- name: pre-validate-controller | Ensure controller replicas is valid (block)
   when:
     - aap_ocp_install_controller['replicas'] is defined
   block:
-    - name: Ensure controller replicas is valid
+    - name: pre-validate-controller | Ensure controller replicas is valid
       ansible.builtin.assert:
         that:
           - (aap_ocp_install_controller['replicas'] | int) > 0
         quiet: true
   rescue:
-    - name: Update validation errors fact - controller replicas
+    - name: pre-validate-controller | Update validation errors fact - controller replicas
       ansible.builtin.set_fact:
         __aap_ocp_install_prevalidate_errors: >
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_controller['replicas'] must be a number greater than 0"] }}
 
-- name: Ensure controller projects storage size is valid (block)
+- name: pre-validate-controller | Ensure controller projects storage size is valid (block)
   when:
     - aap_ocp_install_controller['projects_storage_size'] is defined
   block:
-    - name: Ensure controller projects storage size is valid
+    - name: pre-validate-controller | Ensure controller projects storage size is valid
       ansible.builtin.assert:
         that:
           - (aap_ocp_install_controller['projects_storage_size'] | regex_replace('^(?P<size>[0-9]+)(?P<si>Ki|K|Mi|M|Gi|G|Ti|T|Pi|P|Ei|E)$', '\\g<size>') | int) > 0
           - (aap_ocp_install_controller['projects_storage_size'] | regex_replace('^(?P<size>[0-9]+)(?P<si>Ki|K|Mi|M|Gi|G|Ti|T|Pi|P|Ei|E)$', '\\g<si>')) is in ['Ki','K','Mi','M','Gi','G','Ti','T','Pi','P','Ei','E']
         quiet: true
   rescue:
-    - name: Update validation errors fact - projects_storage_size replicas
+    - name: pre-validate-controller | Update validation errors fact - projects_storage_size replicas
       ansible.builtin.set_fact:
         __aap_ocp_install_prevalidate_errors: >
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_controller['projects_storage_size'] must be a number greater than 0 with a size (e.g. 12Gi or

--- a/roles/aap_ocp_install/tasks/pre-validate-eda.yml
+++ b/roles/aap_ocp_install/tasks/pre-validate-eda.yml
@@ -1,59 +1,59 @@
 ---
-- name: Ensure eda instance name variable is set (block)
+- name: pre-validate-eda | Ensure eda instance name variable is set (block)
   block:
-    - name: Ensure eda instance name variable is set
+    - name: pre-validate-eda | Ensure eda instance name variable is set
       ansible.builtin.assert:
         that:
           - aap_ocp_install_eda['instance_name'] | default('', true) | length > 0
         quiet: true
   rescue:
-    - name: Update validation errors fact - eda instance_name
+    - name: pre-validate-eda | Update validation errors fact - eda instance_name
       ansible.builtin.set_fact:
         __aap_ocp_install_prevalidate_errors: >
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_eda['instance_name'] must be set"] }}
 
-- name: Ensure EDA namespace variable is set (block)
+- name: pre-validate-eda | Ensure EDA namespace variable is set (block)
   when:
     - aap_ocp_install_eda['namespace'] is defined
   block:
-    - name: Ensure EDA namespace variable is set
+    - name: pre-validate-eda | Ensure EDA namespace variable is set
       ansible.builtin.assert:
         that:
           - aap_ocp_install_eda['namespace'] | default("", true) is match('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')
         quiet: true
   rescue:
-    - name: Update validation errors fact - namespace
+    - name: pre-validate-eda | Update validation errors fact - namespace
       ansible.builtin.set_fact:
         __aap_ocp_install_prevalidate_errors: >
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_eda['namespace'] must be a lowercase RFC 1123 label consisting of lower case alphanumeric characters
           or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'"] }}
 
-- name: Ensure EDA link text variable is set (block)
+- name: pre-validate-eda | Ensure EDA link text variable is set (block)
   when:
     - aap_ocp_install_eda['link_text'] is defined
   block:
-    - name: Ensure EDA link text variable is set
+    - name: pre-validate-eda | Ensure EDA link text variable is set
       ansible.builtin.assert:
         that:
           - aap_ocp_install_eda['link_text'] | default('', true) | length > 0
         quiet: true
   rescue:
-    - name: Update validation errors fact - EDA link_text
+    - name: pre-validate-eda | Update validation errors fact - EDA link_text
       ansible.builtin.set_fact:
         __aap_ocp_install_prevalidate_errors: >
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_eda['link_text'] must be a non-empty string"] }}
 
-- name: Ensure EDA replicas is valid (block)
+- name: pre-validate-eda | Ensure EDA replicas is valid (block)
   when:
     - aap_ocp_install_eda['replicas'] is defined
   block:
-    - name: Ensure EDA replicas is valid
+    - name: pre-validate-eda | Ensure EDA replicas is valid
       ansible.builtin.assert:
         that:
           - (aap_ocp_install_eda['replicas'] | int) > 0
         quiet: true
   rescue:
-    - name: Update validation errors fact - EDA replicas
+    - name: pre-validate-eda | Update validation errors fact - EDA replicas
       ansible.builtin.set_fact:
         __aap_ocp_install_prevalidate_errors: >
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_eda['replicas'] must be a number greater than 0"] }}

--- a/roles/aap_ocp_install/tasks/pre-validate-hub.yml
+++ b/roles/aap_ocp_install/tasks/pre-validate-hub.yml
@@ -1,13 +1,13 @@
 ---
-- name: Ensure hub instance name variable is set (block)
+- name: pre-validate-hub | Ensure hub instance name variable is set (block)
   block:
-    - name: Ensure hub instance name variable is set
+    - name: pre-validate-hub | Ensure hub instance name variable is set
       ansible.builtin.assert:
         that:
           - aap_ocp_install_hub['instance_name'] | default('', true) | length > 0
         quiet: true
   rescue:
-    - name: Update validation errors fact - hub instance_name
+    - name: pre-validate-hub | Update validation errors fact - hub instance_name
       ansible.builtin.set_fact:
         __aap_ocp_install_prevalidate_errors: >
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_hub['instance_name'] must be set"] }}

--- a/roles/aap_ocp_install/tasks/pre-validate-operator.yml
+++ b/roles/aap_ocp_install/tasks/pre-validate-operator.yml
@@ -1,13 +1,13 @@
 ---
-- name: Ensure operator channel variable is set (block)
+- name: pre-validate-operator | Ensure operator channel variable is set (block)
   block:
-    - name: Ensure operator channel variable is set
+    - name: pre-validate-operator | Ensure operator channel variable is set
       ansible.builtin.assert:
         that:
           - aap_ocp_install_operator['channel'] | default('', true) | length > 0
         quiet: true
   rescue:
-    - name: Update validation errors fact - channel
+    - name: pre-validate-operator | Update validation errors fact - channel
       ansible.builtin.set_fact:
         __aap_ocp_install_prevalidate_errors: >
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_operator['channel'] must be set"] }}

--- a/roles/aap_ocp_install/tasks/pre-validate-platform.yml
+++ b/roles/aap_ocp_install/tasks/pre-validate-platform.yml
@@ -1,214 +1,214 @@
 ---
-- name: Ensure platform instance name variable is set (block)
+- name: pre-validate-platform | Ensure platform instance name variable is set (block)
   block:
-    - name: Ensure platform instance name variable is set
+    - name: pre-validate-platform | Ensure platform instance name variable is set
       ansible.builtin.assert:
         that:
           - aap_ocp_install_platform['instance_name'] | default('', true) | length > 0
         quiet: true
   rescue:
-    - name: Update validation errors fact - platform instance_name
+    - name: pre-validate-platform | Update validation errors fact - platform instance_name
       ansible.builtin.set_fact:
         __aap_ocp_install_prevalidate_errors: >
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_platform['instance_name'] must be set"] }}
 
-- name: Ensure controller admin username variable is set (block)
+- name: pre-validate-platform | Ensure controller admin username variable is set (block)
   when:
     - aap_ocp_install_controller['admin_user'] is defined
   block:
-    - name: Ensure controller admin username variable is set
+    - name: pre-validate-platform | Ensure controller admin username variable is set
       ansible.builtin.assert:
         that:
           - aap_ocp_install_controller['admin_user'] | default('', true) | length > 0
         quiet: true
   rescue:
-    - name: Update validation errors fact - controller admin_user
+    - name: pre-validate-platform | Update validation errors fact - controller admin_user
       ansible.builtin.set_fact:
         __aap_ocp_install_prevalidate_errors: >
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_controller['admin_user'] must be a non-empty string"] }}
 
-- name: Ensure platform namespace variable is valid if set (block)
+- name: pre-validate-platform | Ensure platform namespace variable is valid if set (block)
   when:
     - aap_ocp_install_platform['namespace'] is defined
   block:
-    - name: Ensure platform namespace variable is valid
+    - name: pre-validate-platform | Ensure platform namespace variable is valid
       ansible.builtin.assert:
         that:
           - aap_ocp_install_platform['namespace'] | default("", true) is match('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')
         quiet: true
   rescue:
-    - name: Update validation errors fact - namespace
+    - name: pre-validate-platform | Update validation errors fact - namespace
       ansible.builtin.set_fact:
         __aap_ocp_install_prevalidate_errors: >
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_platform['namespace'] must be a lowercase RFC 1123 label consisting of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'"] }}
 
-- name: Ensure platform link text variable is valid if set (block)
+- name: pre-validate-platform | Ensure platform link text variable is valid if set (block)
   when:
     - aap_ocp_install_platform['link_text'] is defined
   block:
-    - name: Ensure platform link text variable is set
+    - name: pre-validate-platform | Ensure platform link text variable is set
       ansible.builtin.assert:
         that:
           - aap_ocp_install_controller['link_text'] | default('', true) | length > 0
         quiet: true
   rescue:
-    - name: Update validation errors fact - platform link_text
+    - name: pre-validate-platform | Update validation errors fact - platform link_text
       ansible.builtin.set_fact:
         __aap_ocp_install_prevalidate_errors: >
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_platform['link_text'] must be a non-empty string"] }}
 
-- name: Ensure controller image pull policy is valid (block)
+- name: pre-validate-platform | Ensure controller image pull policy is valid (block)
   when:
     - aap_ocp_install_controller['image_pull_policy'] is defined
   block:
-    - name: Ensure controller image pull policy is valid
+    - name: pre-validate-platform | Ensure controller image pull policy is valid
       ansible.builtin.assert:
         that:
           - aap_ocp_install_controller['image_pull_policy'] is in ['IfNotPresent', 'Always', 'Never']
         quiet: true
   rescue:
-    - name: Update validation errors fact - controller image_pull_policy
+    - name: pre-validate-platform | Update validation errors fact - controller image_pull_policy
       ansible.builtin.set_fact:
         __aap_ocp_install_prevalidate_errors: >
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_controller['image_pull_policy'] must be one of: IfNotPresent, Always, or Never"] }}
 
-- name: Ensure controller create preload data is valid (block)
+- name: pre-validate-platform | Ensure controller create preload data is valid (block)
   when:
     - aap_ocp_install_controller['create_preload_data'] is defined
   block:
-    - name: Ensure controller create preload data is valid
+    - name: pre-validate-platform | Ensure controller create preload data is valid
       ansible.builtin.assert:
         that:
           - (aap_ocp_install_controller['create_preload_data'] | string | lower) is in ['true', 'false']
         quiet: true
   rescue:
-    - name: Update validation errors fact - controller create_preload_data
+    - name: pre-validate-platform | Update validation errors fact - controller create_preload_data
       ansible.builtin.set_fact:
         __aap_ocp_install_prevalidate_errors: >
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_controller['create_preload_data'] must be one of: true or false"] }}
 
-- name: Ensure controller garbage collect secrets is valid (block)
+- name: pre-validate-platform | Ensure controller garbage collect secrets is valid (block)
   when:
     - aap_ocp_install_controller['garbage_collect_secrets'] is defined
   block:
-    - name: Ensure controller garbage collect secrets is valid
+    - name: pre-validate-platform | Ensure controller garbage collect secrets is valid
       ansible.builtin.assert:
         that:
           - (aap_ocp_install_controller['garbage_collect_secrets'] | string | lower) is in ['true', 'false']
         quiet: true
   rescue:
-    - name: Update validation errors fact - controller garbage_collect_secrets
+    - name: pre-validate-platform | Update validation errors fact - controller garbage_collect_secrets
       ansible.builtin.set_fact:
         __aap_ocp_install_prevalidate_errors: >
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_controller['garbage_collect_secrets'] must be one of: true or false"] }}
 
-- name: Ensure controller projects persistence is valid (block)
+- name: pre-validate-platform | Ensure controller projects persistence is valid (block)
   when:
     - aap_ocp_install_controller['projects_persistence'] is defined
   block:
-    - name: Ensure controller projects persistence is valid
+    - name: pre-validate-platform | Ensure controller projects persistence is valid
       ansible.builtin.assert:
         that:
           - (aap_ocp_install_controller['projects_persistence'] | string | lower) is in ['true', 'false']
         quiet: true
   rescue:
-    - name: Update validation errors fact - controller projects_persistence
+    - name: pre-validate-platform | Update validation errors fact - controller projects_persistence
       ansible.builtin.set_fact:
         __aap_ocp_install_prevalidate_errors: >
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_controller['projects_persistence'] must be one of: true or false"] }}
 
-- name: Ensure controller replicas is valid (block)
+- name: pre-validate-platform | Ensure controller replicas is valid (block)
   when:
     - aap_ocp_install_controller['replicas'] is defined
   block:
-    - name: Ensure controller replicas is valid
+    - name: pre-validate-platform | Ensure controller replicas is valid
       ansible.builtin.assert:
         that:
           - (aap_ocp_install_controller['replicas'] | int) > 0
         quiet: true
   rescue:
-    - name: Update validation errors fact - controller replicas
+    - name: pre-validate-platform | Update validation errors fact - controller replicas
       ansible.builtin.set_fact:
         __aap_ocp_install_prevalidate_errors: >
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_controller['replicas'] must be a number greater than 0"] }}
 
-- name: Ensure controller projects storage size is valid (block)
+- name: pre-validate-platform | Ensure controller projects storage size is valid (block)
   when:
     - aap_ocp_install_controller['projects_storage_size'] is defined
   block:
-    - name: Ensure controller projects storage size is valid
+    - name: pre-validate-platform | Ensure controller projects storage size is valid
       ansible.builtin.assert:
         that:
           - (aap_ocp_install_controller['projects_storage_size'] | regex_replace('^(?P<size>[0-9]+)(?P<si>Ki|K|Mi|M|Gi|G|Ti|T|Pi|P|Ei|E)$', '\\g<size>') | int) > 0
           - (aap_ocp_install_controller['projects_storage_size'] | regex_replace('^(?P<size>[0-9]+)(?P<si>Ki|K|Mi|M|Gi|G|Ti|T|Pi|P|Ei|E)$', '\\g<si>')) is in ['Ki','K','Mi','M','Gi','G','Ti','T','Pi','P','Ei','E']
         quiet: true
   rescue:
-    - name: Update validation errors fact - projects_storage_size replicas
+    - name: pre-validate-platform | Update validation errors fact - projects_storage_size replicas
       ansible.builtin.set_fact:
         __aap_ocp_install_prevalidate_errors: >
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_controller['projects_storage_size'] must be a number greater than 0 with a size (e.g. 12Gi or 10000M)"] }}
 
-- name: Ensure hub storage type is valid (block)
+- name: pre-validate-platform | Ensure hub storage type is valid (block)
   when:
     - aap_ocp_install_hub is defined
     - aap_ocp_install_hub['storage_type'] is defined
   block:
-    - name: Ensure hub storage type is valid
+    - name: pre-validate-platform | Ensure hub storage type is valid
       ansible.builtin.assert:
         that:
           - (aap_ocp_install_hub['storage_type']) is in ['file', 'S3', 'azure']
         quiet: true
   rescue:
-    - name: Update validation errors fact - storage_type
+    - name: pre-validate-platform | Update validation errors fact - storage_type
       ansible.builtin.set_fact:
         __aap_ocp_install_prevalidate_errors: >
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_hub['storage_type'] must be 'file', 'S3' or 'azure'"] }}
 
-- name: Ensure hub file storage settings are valid (block)
+- name: pre-validate-platform | Ensure hub file storage settings are valid (block)
   when:
     - aap_ocp_install_hub['storage_type'] is defined
     - aap_ocp_install_hub['storage_type'] == 'file'
   block:
-    - name: Ensure hub file storage settings are valid
+    - name: pre-validate-platform | Ensure hub file storage settings are valid
       ansible.builtin.assert:
         that:
           - (aap_ocp_install_hub['file_storage_size'] is not defined) or (aap_ocp_install_hub['file_storage_size'] | regex_replace('^(?P<size>[0-9]+)(?P<si>Ki|K|Mi|M|Gi|G|Ti|T|Pi|P|Ei|E)$', '\\g<size>') | int) > 0
           - (aap_ocp_install_hub['file_storage_size'] is not defined) or (aap_ocp_install_hub['file_storage_size'] | regex_replace('^(?P<size>[0-9]+)(?P<si>Ki|K|Mi|M|Gi|G|Ti|T|Pi|P|Ei|E)$', '\\g<si>')) is in ['Ki','K','Mi','M','Gi','G','Ti','T','Pi','P','Ei','E']
         quiet: true
   rescue:
-    - name: Update validation errors fact - file storage_type
+    - name: pre-validate-platform | Update validation errors fact - file storage_type
       ansible.builtin.set_fact:
         __aap_ocp_install_prevalidate_errors: >
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_hub['file_storage_size'] must be a number greater than 0 with a size (e.g. 12Gi or 10000M)"] }}
 
-- name: Ensure hub S3 storage settings are valid (block)
+- name: pre-validate-platform | Ensure hub S3 storage settings are valid (block)
   when:
     - aap_ocp_install_hub['storage_type'] is defined
     - aap_ocp_install_hub['storage_type'] == 'S3'
   block:
-    - name: Ensure hub S3 storage settings are valid
+    - name: pre-validate-platform | Ensure hub S3 storage settings are valid
       ansible.builtin.assert:
         that:
           - (aap_ocp_install_hub['object_storage_s3_secret']) is defined
         quiet: true
   rescue:
-    - name: Update validation errors fact - S3 secret
+    - name: pre-validate-platform | Update validation errors fact - S3 secret
       ansible.builtin.set_fact:
         __aap_ocp_install_prevalidate_errors: >
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_hub['object_storage_s3_secret'] must be the name of a valid S3 storage secret name"] }}
 
-- name: Ensure hub Azure storage settings are valid (block)
+- name: pre-validate-platform | Ensure hub Azure storage settings are valid (block)
   when:
     - aap_ocp_install_hub['storage_type'] is defined
     - aap_ocp_install_hub['storage_type'] == 'azure'
   block:
-    - name: Ensure hub Azure storage settings are valid
+    - name: pre-validate-platform | Ensure hub Azure storage settings are valid
       ansible.builtin.assert:
         that:
           - (aap_ocp_install_hub['object_storage_azure_secret']) is defined
         quiet: true
   rescue:
-    - name: Update validation errors fact - Azure secret
+    - name: pre-validate-platform | Update validation errors fact - Azure secret
       ansible.builtin.set_fact:
         __aap_ocp_install_prevalidate_errors: >
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_hub['object_storage_azure_secret'] must be the name of a valid Azure storage secret name"] }}

--- a/roles/aap_ocp_install/tasks/pre-validate.yml
+++ b/roles/aap_ocp_install/tasks/pre-validate.yml
@@ -1,104 +1,104 @@
 ---
-- name: Ensure OpenShift host variable is set (block)
+- name: pre-validate | Ensure OpenShift host variable is set (block)
   block:
-    - name: Ensure OpenShift host variable is set
+    - name: pre-validate | Ensure OpenShift host variable is set
       ansible.builtin.assert:
         that:
           - aap_ocp_install_connection['host'] is defined
           - aap_ocp_install_connection['host'] | default("", true) | length > 0
         quiet: true
   rescue:
-    - name: Update validation errors fact - host
+    - name: pre-validate | Update validation errors fact - host
       ansible.builtin.set_fact:
         __aap_ocp_install_prevalidate_errors: >
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_connection['host'] must be set"] }}
 
-- name: Ensure OpenShift username and password variables are not set when API Token set (block)
+- name: pre-validate | Ensure OpenShift username and password variables are not set when API Token set (block)
   when:
     - aap_ocp_install_connection['api_key'] is defined
   block:
-    - name: Ensure OpenShift username and password variables are not set when API Token set
+    - name: pre-validate | Ensure OpenShift username and password variables are not set when API Token set
       ansible.builtin.assert:
         that:
           - aap_ocp_install_connection['username'] is not defined
           - aap_ocp_install_connection['password'] is not defined
         quiet: true
   rescue:
-    - name: Update validation errors fact - username
+    - name: pre-validate | Update validation errors fact - username
       ansible.builtin.set_fact:
         __aap_ocp_install_prevalidate_errors: >
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_connection['username'] or aap_ocp_install_connection['password'] must not be set when aap_ocp_install_connection['api_key']
           is set"] }}
 
-- name: Ensure OpenShift API token variable is set (block)
+- name: pre-validate | Ensure OpenShift API token variable is set (block)
   when:
     - aap_ocp_install_connection['api_key'] is defined
   block:
-    - name: Ensure OpenShift API token variable is set
+    - name: pre-validate | Ensure OpenShift API token variable is set
       ansible.builtin.assert:
         that:
           - aap_ocp_install_connection['api_key'] is defined
           - aap_ocp_install_connection['api_key'] | default("", true) | length > 0
         quiet: true
   rescue:
-    - name: Update validation errors fact - api_key
+    - name: pre-validate | Update validation errors fact - api_key
       ansible.builtin.set_fact:
         __aap_ocp_install_prevalidate_errors: >
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_connection['api_key'] must be set"] }}
 
-- name: Ensure OpenShift username variable is set (block)
+- name: pre-validate | Ensure OpenShift username variable is set (block)
   when:
     - aap_ocp_install_connection['api_key'] is not defined
   block:
-    - name: Ensure OpenShift username variable is set
+    - name: pre-validate | Ensure OpenShift username variable is set
       ansible.builtin.assert:
         that:
           - aap_ocp_install_connection['username'] is defined
           - aap_ocp_install_connection['username'] | default("", true) | length > 0
         quiet: true
   rescue:
-    - name: Update validation errors fact - username
+    - name: pre-validate | Update validation errors fact - username
       ansible.builtin.set_fact:
         __aap_ocp_install_prevalidate_errors: >
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_connection['username'] must be set"] }}
 
-- name: Ensure OpenShift password variable is set (block)
+- name: pre-validate | Ensure OpenShift password variable is set (block)
   when:
     - aap_ocp_install_connection['api_key'] is not defined
   block:
-    - name: Ensure OpenShift password variable is set
+    - name: pre-validate | Ensure OpenShift password variable is set
       ansible.builtin.assert:
         that:
           - aap_ocp_install_connection['password'] is defined
           - aap_ocp_install_connection['password'] | default("", true) | length > 0
         quiet: true
   rescue:
-    - name: Update validation errors fact - password
+    - name: pre-validate | Update validation errors fact - password
       ansible.builtin.set_fact:
         __aap_ocp_install_prevalidate_errors: >
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_connection['password'] must be set"] }}
 
-- name: Ensure OpenShift namespace variable is set (block)
+- name: pre-validate | Ensure OpenShift namespace variable is set (block)
   block:
-    - name: Ensure OpenShift namespace variable is set
+    - name: pre-validate | Ensure OpenShift namespace variable is set
       ansible.builtin.assert:
         that:
           - (aap_ocp_install_namespace | default("", true) | regex_search('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')) is not none
         quiet: true
   rescue:
-    - name: Update validation errors fact - namespace
+    - name: pre-validate | Update validation errors fact - namespace
       ansible.builtin.set_fact:
         __aap_ocp_install_prevalidate_errors: >
           {{ __aap_ocp_install_prevalidate_errors + ["aap_ocp_install_namespace must be a lowercase RFC 1123 label consisting of lower case alphanumeric characters
           or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'"] }}
 
-- name: Ensure operator variables are set
+- name: pre-validate | Ensure operator variables are set
   when:
     - ( 'operator' in ansible_run_tags ) or ( 'all' in ansible_run_tags and aap_ocp_install_operator is defined )
   ansible.builtin.include_tasks:
     file: pre-validate-operator.yml
 
-- name: Retrieve the requested operator channel version numbers
+- name: pre-validate | Retrieve the requested operator channel version numbers
   ansible.builtin.set_fact:
     __aap_ocp_install_major_version: "{{ aap_ocp_install_operator['channel'] | regex_search(__aap_ocp_install_major_version_re, '\\1') | first }}"
     __aap_ocp_install_minor_version: "{{ aap_ocp_install_operator['channel'] | regex_search(__aap_ocp_install_minor_version_re, '\\1') | first }}"
@@ -106,41 +106,41 @@
     __aap_ocp_install_major_version_re: '(\d+)\.\d+'
     __aap_ocp_install_minor_version_re: '\d+\.(\d+)'
 
-- name: Set a flag indicating whether to use the new (AAP 2.5+) operator installation method
+- name: pre-validate | Set a flag indicating whether to use the new (AAP 2.5+) operator installation method
   ansible.builtin.set_fact:
     __aap_ocp_install_25_install: "{{ (__aap_ocp_install_major_version | int) > 2 \
                                   or ((__aap_ocp_install_major_version | int) == 2 \
                                   and (__aap_ocp_install_minor_version | int) >= 5) }}"
 
-- name: Ensure platform variables are set
+- name: pre-validate | Ensure platform variables are set
   when:
     - (( 'platform' in ansible_run_tags ) or ( 'all' in ansible_run_tags and aap_ocp_install_platform is defined ))
     - (__aap_ocp_install_25_install | bool)
   ansible.builtin.include_tasks:
     file: pre-validate-platform.yml
 
-- name: Ensure controller variables are set
+- name: pre-validate | Ensure controller variables are set
   when:
     - (( 'controller' in ansible_run_tags ) or ( 'all' in ansible_run_tags and aap_ocp_install_controller is defined ))
     - not (__aap_ocp_install_25_install | bool)
   ansible.builtin.include_tasks:
     file: pre-validate-controller.yml
 
-- name: Ensure hub variables are set
+- name: pre-validate | Ensure hub variables are set
   when:
     - (( 'hub' in ansible_run_tags ) or ( 'all' in ansible_run_tags and aap_ocp_install_hub is defined ))
     - not (__aap_ocp_install_25_install | bool)
   ansible.builtin.include_tasks:
     file: pre-validate-hub.yml
 
-- name: Ensure eda variables are set
+- name: pre-validate | Ensure eda variables are set
   when:
     - (( 'eda' in ansible_run_tags ) or ( 'all' in ansible_run_tags and aap_ocp_install_eda is defined ))
     - not (__aap_ocp_install_25_install | bool)
   ansible.builtin.include_tasks:
     file: pre-validate-eda.yml
 
-- name: Ensure no validation errors found
+- name: pre-validate | Ensure no validation errors found
   ansible.builtin.debug:
     msg:
       - "The following errors must be fixed to continue:"

--- a/roles/aap_ocp_install/tasks/validate-connection.yml
+++ b/roles/aap_ocp_install/tasks/validate-connection.yml
@@ -1,5 +1,5 @@
 ---
-- name: Validate OpenShift API key
+- name: validate-connection | Validate OpenShift API key
   ansible.builtin.uri:
     url: "{{  __aap_ocp_install_auth_results['openshift_auth']['host'] }}/version"
     method: GET

--- a/roles/aap_remove/tasks/ah_remove.yml
+++ b/roles/aap_remove/tasks/ah_remove.yml
@@ -1,5 +1,5 @@
 ---
-- name: Stop and disable services
+- name: ah_remove | Stop and disable services
   ansible.builtin.systemd:
     name: "{{ item }}"
     state: stopped
@@ -15,7 +15,7 @@
     - redis.service
   become: true
 
-- name: Remove software
+- name: ah_remove | Remove software
   ansible.builtin.dnf:
     name:
       - postgresql
@@ -35,7 +35,7 @@
     autoremove: true
   become: true
 
-- name: Remove created directories
+- name: ah_remove | Remove created directories
   ansible.builtin.file:
     path: "{{ item }}"
     state: absent
@@ -46,7 +46,7 @@
     - /root/hub
   become: true
 
-- name: Remove added users
+- name: ah_remove | Remove added users
   ansible.builtin.user:
     name: "{{ item }}"
     state: absent
@@ -59,7 +59,7 @@
     - nginx
   become: true
 
-- name: Remove added groups
+- name: ah_remove | Remove added groups
   ansible.builtin.group:
     name: "{{ item }}"
     state: absent

--- a/roles/aap_remove/tasks/controller_remove.yml
+++ b/roles/aap_remove/tasks/controller_remove.yml
@@ -1,7 +1,7 @@
 ---
 # Following this article: https://access.redhat.com/solutions/6733721
 
-- name: Stop and disable services
+- name: controller_remove | Stop and disable services
   ansible.builtin.systemd:
     name: "{{ item }}"
     state: stopped
@@ -16,7 +16,7 @@
     - supervisord.service
     - receptor.service
 
-- name: Remove software
+- name: controller_remove | Remove software
   ansible.builtin.dnf:
     name:
       - postgresql
@@ -30,7 +30,7 @@
     autoremove: true
   become: true
 
-- name: Remove created directories
+- name: controller_remove | Remove created directories
   ansible.builtin.file:
     path: "{{ item }}"
     state: absent
@@ -43,7 +43,7 @@
     - /var/lib/automation-platform-bundle
   become: true
 
-- name: Remove added users
+- name: controller_remove | Remove added users
   ansible.builtin.user:
     name: "{{ item }}"
     state: absent
@@ -57,7 +57,7 @@
     - receptor
   become: true
 
-- name: Remove added groups
+- name: controller_remove | Remove added groups
   ansible.builtin.group:
     name: "{{ item }}"
     state: absent

--- a/roles/aap_restore/tasks/restore.yml
+++ b/roles/aap_restore/tasks/restore.yml
@@ -1,6 +1,6 @@
 ---
 # Run the Setup to restore AAP
-- name: Run the Ansible AAP Setup Program with restore option
+- name: restore | Run the Ansible AAP Setup Program with restore option
   become: true
   ansible.builtin.command: ./setup.sh -e 'restore_backup_file={{ aap_restore_location | quote }}' -r
   args:

--- a/roles/aap_setup_install/tasks/containerized.yml
+++ b/roles/aap_setup_install/tasks/containerized.yml
@@ -1,5 +1,5 @@
 ---
-- name: Check Automation Controller Running
+- name: containerized | Check Automation Controller Running
   ansible.builtin.uri:
     url: https://{{ controller_hostname }}:{{ __aap_setup_inst_controller_port }}/api/
     method: GET
@@ -14,7 +14,7 @@
     - "'automationcontroller' in aap_setup_prep_inv_nodes"
     - not aap_setup_inst_force | bool
 
-- name: Check Automation Hub Running
+- name: containerized | Check Automation Hub Running
   ansible.builtin.uri:
     url: https://{{ ah_hostname }}:{{ __aap_setup_inst_hub_port }}/api/galaxy/
     method: GET
@@ -29,7 +29,7 @@
     - "'automationhub' in aap_setup_prep_inv_nodes"
     - not aap_setup_inst_force | bool
 
-- name: Check EDA Controller Running
+- name: containerized | Check EDA Controller Running
   ansible.builtin.uri:
     url: https://{{ eda_hostname }}:{{ __aap_setup_inst_eda_port }}/
     method: GET
@@ -44,7 +44,7 @@
     - "'automationeda' in aap_setup_prep_inv_nodes"
     - not aap_setup_inst_force | bool
 
-- name: Install AAP
+- name: containerized | Install AAP
   when: >
     aap_setup_inst_force
     or ('automationcontroller' in aap_setup_prep_inv_nodes
@@ -54,7 +54,7 @@
     or ('automationeda' in aap_setup_prep_inv_nodes
         and __aap_setup_inst_eda_check.status != 200)
   block:
-    - name: Copy extra vars files to workspace
+    - name: containerized | Copy extra vars files to workspace
       ansible.builtin.copy:
         src: "{{ item }}"
         dest: "{{ aap_setup_inst_setup_dir }}"
@@ -62,14 +62,14 @@
       loop: "{{ aap_setup_inst_extra_vars_files }}"
       register: __extra_vars_files
 
-    - name: Updated log file location
+    - name: containerized | Updated log file location
       when: aap_setup_inst_log_dir is defined
       ansible.builtin.template:
         src: ansible.cfg.j2
         dest: "{{ aap_setup_inst_setup_dir }}/ansible.cfg"
         mode: "0644"
 
-    - name: Run the Ansible Automation Platform setup program
+    - name: containerized | Run the Ansible Automation Platform setup program
       ansible.builtin.command: "{{ lookup('template', 'containerized_sh.j2') }}"
       args:
         chdir: "{{ aap_setup_inst_setup_dir }}"
@@ -78,7 +78,7 @@
       changed_when: false
       # these will always run and will always report "changed" otherwise
 
-    - name: Wait for automation controller to be running
+    - name: containerized | Wait for automation controller to be running
       ansible.builtin.uri: # use the first host from the list if no hostname is defined
         url: https://{{ controller_hostname }}:{{ __aap_setup_inst_controller_port }}/api/
         method: GET
@@ -93,7 +93,7 @@
       delay: 10
       when: "'automationcontroller' in aap_setup_prep_inv_nodes"
 
-    - name: Wait for automation hub to be running
+    - name: containerized | Wait for automation hub to be running
       ansible.builtin.uri: # use the first host from the list if no hostname is defined
         url: https://{{ ah_hostname }}:{{ __aap_setup_inst_hub_port }}/api/galaxy/
         method: GET
@@ -108,7 +108,7 @@
       delay: 10
       when: "'automationhub' in aap_setup_prep_inv_nodes"
 
-    - name: Wait for EDA controller to be running
+    - name: containerized | Wait for EDA controller to be running
       ansible.builtin.uri: # use the first host from the list if no hostname is defined
         url: https://{{ eda_hostname }}:{{ __aap_setup_inst_eda_port }}/
         method: GET

--- a/roles/aap_setup_install/tasks/setup.yml
+++ b/roles/aap_setup_install/tasks/setup.yml
@@ -1,5 +1,5 @@
 ---
-- name: Check Automation Controller Running
+- name: setup | Check Automation Controller Running
   ansible.builtin.uri:
     url: https://{{ controller_hostname }}/
     method: GET
@@ -15,7 +15,7 @@
     - aap_setup_down_version is version('2.5', '<')
     - not aap_setup_inst_force | bool
 
-- name: Check Automation Hub Running
+- name: setup | Check Automation Hub Running
   ansible.builtin.uri:
     url: https://{{ ah_hostname }}/api/galaxy/
     method: GET
@@ -31,7 +31,7 @@
     - aap_setup_down_version is version('2.5', '<')
     - not aap_setup_inst_force | bool
 
-- name: Check EDA Controller Running
+- name: setup | Check EDA Controller Running
   ansible.builtin.uri:
     url: https://{{ eda_hostname }}/
     method: GET
@@ -47,7 +47,7 @@
     - aap_setup_down_version is version('2.5', '<')
     - not aap_setup_inst_force | bool
 
-- name: Check Gateway API Status
+- name: setup | Check Gateway API Status
   ansible.builtin.uri:
     url: https://{{ gateway_hostname }}/api/gateway/v1/status/?service_keys=true
     method: GET
@@ -63,7 +63,7 @@
     - aap_setup_down_version is version('2.5', '>=')
     - not aap_setup_inst_force | bool
 
-- name: Install AAP
+- name: setup | Install AAP
   when: >
     aap_setup_inst_force
     or ('automationcontroller' in aap_setup_prep_inv_nodes
@@ -76,7 +76,7 @@
       and (aap_setup_down_version is version('2.5', '>=') |
       ternary(__aap_setup_inst_gateway_check.json.services.eda.status | default('') != 'good',  __aap_setup_inst_ctl_eda.status | default(401) != 200)))
   block:
-    - name: Copy extra vars files to workspace
+    - name: setup | Copy extra vars files to workspace
       ansible.builtin.copy:
         src: "{{ item }}"
         dest: "{{ aap_setup_inst_setup_dir }}"
@@ -84,7 +84,7 @@
       loop: "{{ aap_setup_inst_extra_vars_files }}"
       register: __extra_vars_files
 
-    - name: Run the Ansible Automation Platform setup program
+    - name: setup | Run the Ansible Automation Platform setup program
       ansible.builtin.command: "{{ lookup('template', 'setup_sh.j2') }}"
       args:
         chdir: "{{ aap_setup_inst_setup_dir }}"
@@ -93,7 +93,7 @@
       changed_when: false
       # these will always run and will always report "changed" otherwise
 
-    - name: Wait for automation controller to be running
+    - name: setup | Wait for automation controller to be running
       ansible.builtin.uri: # use the first host from the list if no hostname is defined
         url: https://{{ controller_hostname }}/
         method: GET
@@ -110,7 +110,7 @@
         - "'automationcontroller' in aap_setup_prep_inv_nodes"
         - aap_setup_down_version is version('2.5', '<')
 
-    - name: Wait for automation hub to be running
+    - name: setup | Wait for automation hub to be running
       ansible.builtin.uri: # use the first host from the list if no hostname is defined
         url: https://{{ ah_hostname }}/api/galaxy/
         method: GET
@@ -127,7 +127,7 @@
         - "'automationhub' in aap_setup_prep_inv_nodes"
         - aap_setup_down_version is version('2.5', '<')
 
-    - name: Wait for EDA controller to be running
+    - name: setup | Wait for EDA controller to be running
       ansible.builtin.uri: # use the first host from the list if no hostname is defined
         url: https://{{ eda_hostname }}/
         method: GET
@@ -143,7 +143,7 @@
         - "'automationedacontroller' in aap_setup_prep_inv_nodes"
         - aap_setup_down_version is version('2.5', '<')
 
-    - name: Wait for Automation Controller service to be running
+    - name: setup | Wait for Automation Controller service to be running
       ansible.builtin.uri: # use the first host from the list if no hostname is defined
         url: https://{{ gateway_hostname }}/api/gateway/v1/status/?service_keys=true
         method: GET
@@ -159,7 +159,7 @@
         - "'automationcontroller' in aap_setup_prep_inv_nodes"
         - aap_setup_down_version is version('2.5', '>=')
 
-    - name: Wait for Automation Hub service to be running
+    - name: setup | Wait for Automation Hub service to be running
       ansible.builtin.uri: # use the first host from the list if no hostname is defined
         url: https://{{ gateway_hostname }}/api/gateway/v1/status/?service_keys=true
         method: GET
@@ -175,7 +175,7 @@
         - "'automationhub' in aap_setup_prep_inv_nodes"
         - aap_setup_down_version is version('2.5', '>=')
 
-    - name: Wait for EDA Controller service to be running
+    - name: setup | Wait for EDA Controller service to be running
       ansible.builtin.uri: # use the first host from the list if no hostname is defined
         url: https://{{ gateway_hostname }}/api/gateway/v1/status/?service_keys=true
         method: GET
@@ -191,7 +191,7 @@
         - "'automationedacontroller' in aap_setup_prep_inv_nodes"
         - aap_setup_down_version is version('2.5', '>=')
 
-    - name: Wait for Automation Gateway service to be running
+    - name: setup | Wait for Automation Gateway service to be running
       ansible.builtin.uri: # use the first host from the list if no hostname is defined
         url: https://{{ gateway_hostname }}/api/gateway/v1/ping/
         method: GET

--- a/roles/git_ssh_setup/tasks/git_users.yml
+++ b/roles/git_ssh_setup/tasks/git_users.yml
@@ -1,7 +1,7 @@
 ---
 # tasks file for git_ssh_setup
 
-- name: Git_users | add client user to group - {{ git_server_user }}
+- name: git_users | Add client user to group - {{ git_server_user }}
   ansible.builtin.user:
     name: "{{ client_item.name }}"
     groups: "{{ git_server_user }}" # group has been created with the user of same name
@@ -10,7 +10,7 @@
     ssh_key_type: "{{ client_item.ssh_key_type | default(omit) }}"
   register: user_result
 
-- name: Git_users | add the public keys to the git user authorized keys
+- name: git_users | Add the public keys to the git user authorized keys
   ansible.posix.authorized_key:
     user: "{{ git_server_user }}"
     state: present


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

Add consistently prefix to name of tasks in non-main tasks files as per good practices for Ansible, to more easily identify where tasks are defined

# How should this be tested?

Just run any playbook and see  the prefixes added to all tasks not in a main.yml... No functionality change to check.

# Is there a relevant Issue open for this?

n/a

# Other Relevant info, PRs, etc

n/a