### PR TITLE
chore: security audit remediations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+---
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10

--- a/.github/workflows/issue-close-inactive.yml
+++ b/.github/workflows/issue-close-inactive.yml
@@ -6,12 +6,15 @@ on:
   schedule:
     - cron: "0 6 * * *"
 
+permissions:
+  issues: write
+
 jobs:
   close-inactive-issues:
     runs-on: ubuntu-latest
     steps:
       - name: close-issues
-        uses: actions-cool/issues-helper@v3
+        uses: actions-cool/issues-helper@200c78641dbf33838311e5a1e0c31bbdb92d7cf0 # v3
         with:
           actions: 'close-issues'
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/issue-find-inactive.yml
+++ b/.github/workflows/issue-find-inactive.yml
@@ -6,12 +6,15 @@ on:
   schedule:
     - cron: "0 5 * * *"
 
+permissions:
+  issues: write
+
 jobs:
   check-inactive:
     runs-on: ubuntu-latest
     steps:
       - name: check-inactive
-        uses: actions-cool/issues-helper@v3
+        uses: actions-cool/issues-helper@200c78641dbf33838311e5a1e0c31bbdb92d7cf0 # v3
         with:
           actions: 'check-inactive'
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -6,12 +6,15 @@ on:
   issues:
     types: [labeled]
 
+permissions:
+  issues: write
+
 jobs:
   issue-labeled:
     runs-on: ubuntu-latest
     steps:
       - name: Create comment
-        uses: actions-cool/issues-helper@v3
+        uses: actions-cool/issues-helper@200c78641dbf33838311e5a1e0c31bbdb92d7cf0 # v3
         if: github.event.label.name == 'inactive'  # || github.event.label.name == 'need info'
         with:
           actions: 'create-comment'

--- a/.github/workflows/issue-remove-inactive.yml
+++ b/.github/workflows/issue-remove-inactive.yml
@@ -8,13 +8,16 @@ on:
   issue_comment:
     types: [created, edited]
 
+permissions:
+  issues: write
+
 jobs:
   remove-inactive:
     runs-on: ubuntu-latest
     steps:
       - name: remove inactive
         if: github.event.issue.state == 'open' && github.event.issue.user != 'github-actions'
-        uses: actions-cool/issues-helper@v3
+        uses: actions-cool/issues-helper@200c78641dbf33838311e5a1e0c31bbdb92d7cf0 # v3
         with:
           actions: 'remove-labels'
           issue-number: ${{ github.event.issue.number }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,6 +10,10 @@ on:
   schedule:
     - cron: "0 6 * * *"
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   pre-commit_and_sanity:
     uses: "redhat-cop/ansible_collections_tooling/.github/workflows/pre_commit_and_sanity.yml@main"

--- a/.github/workflows/update_pre_commit.yml
+++ b/.github/workflows/update_pre_commit.yml
@@ -8,6 +8,10 @@ on:
   schedule:
     - cron: "0 5 * * *"
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   pre-commit:
     uses: "redhat-cop/ansible_collections_tooling/.github/workflows/update_precommit.yml@main"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# Local secrets and credentials
+.env
+*.pem
+*.key
+
 # Ignore PyCache and compiled python
 **/__pycache__/**
 *.pyc


### PR DESCRIPTION
## Summary

- Added explicit workflow permissions and pinned third-party actions to SHAs (CodeQL).
- Added Dependabot for GitHub Actions.
- Expanded `.gitignore` for common secret material.

## Details

**Repo:** `redhat-cop/aap_utilities` | **Base branch:** `devel`

- **CodeQL alerts #1–4, 6–7** (`missing-workflow-permissions`): Added explicit permissions to issue workflows, `pre-commit.yml`, `update_pre_commit.yml`
- **CodeQL alerts #8–11** (`unpinned-tag`): Pinned `actions-cool/issues-helper` to SHA
- **No `pull_request_target`** usage found
- **Dependabot**: Created `.github/dependabot.yml` for `github-actions` (weekly)
- **`.gitignore`**: Added `.env`, `*.pem`, `*.key`

Made with [Cursor](https://cursor.com)