### PR TITLE
Updated default versions and installation methods

### DIFF
--- a/changelogs/fragments/bump-default-installation.yml
+++ b/changelogs/fragments/bump-default-installation.yml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - Fixed readme because containerized-setup isn't a valid download type
+breaking_changes:
+  - The default installation is now containerized of AAP 2.6 on RHEL 10, instead of RPM of AAP 2.5 on RHEL 8

--- a/roles/aap_setup_download/README.md
+++ b/roles/aap_setup_download/README.md
@@ -15,15 +15,16 @@ The following input variables are required:
 
 * `aap_setup_down_offline_token` contains your offline token as described in the requirements.
 It has no default value and _must_ be defined.
-* `aap_setup_down_version` defines the minor version to download (e.g. `2.5`). Defaults to current latest `2.5` version.
+* `aap_setup_down_version` defines the minor version to download (e.g. `2.6`). Defaults to current latest `2.6` version.
 The default is the latest version available at time of writing.
-* `aap_setup_down_version_patch` defines the patch version to download (e.g `12`) Defaults to false which will always get latest.
+* `aap_setup_down_version_patch` defines the patch version to download (e.g `7`).
+  Defaults to `false` which will always get latest.
 * `aap_setup_down_dest_dir` is the directory to where you want to download the tarball.
 It is by default the working directory `aap_setup_working_dir` also used by other roles of the collection, or ultimately `/var/tmp`.
-* `aap_setup_down_type` can be either `setup`, `setup-bundle`, `containerized-setup`, depending which flavour of the tarball you want to download.
-* `aap_setup_rhel_version` defines the major RHEL version being used (currently 8 or 9). If you are gathering facts you possibly don't need to specify this as the role will attempt to work out the value required though you will if AAP will be installed on machines on a different OS than the installer will run on. Otherwise the default is 8.
+* `aap_setup_down_type` can be either `setup` or `setup-bundle`, depending on which flavour of the tarball you want to download.
+* `aap_setup_rhel_version` defines the major RHEL version being used (currently 8, 9 or 10). If you are gathering facts you possibly don't need to specify this as the role will attempt to work out the value required though you will if AAP will be installed on machines on a different OS than the installer will run on. Otherwise the default is 10.
 * `aap_setup_containerized` if set to `true` the role will download the the containerized installer.
-* `aap_setup_arch` define the processor architecture of the installer. Default to "x86_64"
+* `aap_setup_arch` define the processor architecture of the installer. Default to `x86_64`
 
 The full path of the downloaded file is stored in the fact `aap_setup_down_installer_file` so that it can be used for extraction.
 

--- a/roles/aap_setup_download/defaults/main.yml
+++ b/roles/aap_setup_download/defaults/main.yml
@@ -7,16 +7,17 @@
 # aap_setup_down_offline_token:
 
 # which version of the installer to download
-aap_setup_down_version: "2.5"
+aap_setup_down_version: "2.6"
 
-# Which minor version to download, eg {{ aap_setup_down_version }}-12
-aap_setup_down_version_patch: false  # set to false to download the latest version, 12 for 2.5-12
+# Which minor version to download
+# Set to false to download the latest version, or e.g. 7 for 2.6-7
+aap_setup_down_version_patch: false
 
 # Which system architecture to download for
 aap_setup_arch: x86_64
 
-# Which RHEL version are you using (8 or 9)
-aap_setup_rhel_version: "{{ ansible_distribution_major_version | default(8, true) }}"
+# Which RHEL version are you using (8, 9 or 10)
+aap_setup_rhel_version: "{{ ansible_distribution_major_version | default(10, true) }}"
 
 # where to download the setup installer file
 aap_setup_down_dest_dir: "{{ aap_setup_working_dir | default('/var/tmp') }}"
@@ -25,5 +26,5 @@ aap_setup_down_dest_dir: "{{ aap_setup_working_dir | default('/var/tmp') }}"
 aap_setup_down_type: setup-bundle
 
 # Download containerized installer
-aap_setup_containerized: false
+aap_setup_containerized: true
 ...

--- a/roles/aap_setup_install/README.md
+++ b/roles/aap_setup_install/README.md
@@ -54,6 +54,7 @@ Else change to `become: true`.
 ```yaml
 ---
 aap_setup_down_type: "setup-bundle"
+aap_setup_containerized: false
 aap_setup_rhel_version: 8
 
 aap_setup_prep_inv_nodes:  # a dictionary of dictionaries!

--- a/roles/aap_setup_prepare/README.md
+++ b/roles/aap_setup_prepare/README.md
@@ -58,6 +58,7 @@ Else change to `become: true`.
 ```yaml
 ---
 aap_setup_down_type: "setup-bundle"
+aap_setup_containerized: false
 aap_setup_rhel_version: 8
 
 aap_setup_prep_inv_nodes:  # a dictionary of dictionaries!


### PR DESCRIPTION


<!--- markdownlint-disable MD041 -->
# What does this PR do?

- Fixed readme because containerized-setup isn't a valid download type
- The default installation is now containerized of AAP 2.6 on RHEL 10, instead of RPM of AAP 2.5 on RHEL 8

# How should this be tested?

You may install AAP and see that the defaults have changed

# Is there a relevant Issue open for this?

No

# Other Relevant info, PRs, etc

n/a