### PR TITLE
fix(role): handle both dict and list types for hostname variables

### DIFF
--- a/changelogs/fragments/fix-hostname-type-mismatch.yml
+++ b/changelogs/fragments/fix-hostname-type-mismatch.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - "aap_setup_install - handle both dict and list types for ``aap_setup_prep_inv_nodes`` hostname variables, fixing ``'list object' has no attribute 'keys'`` errors when inventory nodes are provided as a list (https://github.com/redhat-cop/aap_utilities/issues/327)."
+...

--- a/roles/aap_setup_install/defaults/main.yml
+++ b/roles/aap_setup_install/defaults/main.yml
@@ -54,7 +54,7 @@ aap_setup_inst_extra_vars: {}
 # You shouldn't need to define them again and again but they should be defined
 #
 # controller_hostname: "{{ inventory_hostname }}"
-controller_hostname: "{{ (aap_setup_prep_inv_nodes['automationcontroller'].keys() | list)[0] }}"
+controller_hostname: "{{ (aap_setup_prep_inv_nodes['automationcontroller'] is mapping) | ternary((aap_setup_prep_inv_nodes['automationcontroller'].keys() | list)[0], aap_setup_prep_inv_nodes['automationcontroller'][0]) }}"
 # controller_username: "admin"
 # controller_password: ""
 # controller_oauthtoken: ""
@@ -66,17 +66,17 @@ controller_hostname: "{{ (aap_setup_prep_inv_nodes['automationcontroller'].keys(
 # You shouldn't need to define them again and again but they should be defined
 #
 # ah_hostname: "{{ inventory_hostname }}"
-ah_hostname: "{{ (aap_setup_prep_inv_nodes['automationhub'].keys() | list)[0] }}"
+ah_hostname: "{{ (aap_setup_prep_inv_nodes['automationhub'] is mapping) | ternary((aap_setup_prep_inv_nodes['automationhub'].keys() | list)[0], aap_setup_prep_inv_nodes['automationhub'][0]) }}"
 # ah_username: "admin"
 # ah_password: ""
 # ah_oauthtoken: ""
 # ah_validate_certs: false
 
-eda_hostname: "{{ (aap_setup_prep_inv_nodes[__aap_setup_inst_eda_group_name].keys() | list)[0] }}"
+eda_hostname: "{{ (aap_setup_prep_inv_nodes[__aap_setup_inst_eda_group_name] is mapping) | ternary((aap_setup_prep_inv_nodes[__aap_setup_inst_eda_group_name].keys() | list)[0], aap_setup_prep_inv_nodes[__aap_setup_inst_eda_group_name][0]) }}"
 # eda_validate_certs: false
 
 # gateway_hostname: "{{ inventory_hostname }}"
-gateway_hostname: "{{ (aap_setup_prep_inv_nodes['automationgateway'].keys() | list)[0] }}"
+gateway_hostname: "{{ (aap_setup_prep_inv_nodes['automationgateway'] is mapping) | ternary((aap_setup_prep_inv_nodes['automationgateway'].keys() | list)[0], aap_setup_prep_inv_nodes['automationgateway'][0]) }}"
 # gateway_username: "admin"
 # gateway_password: ""
 # gateway_oauthtoken: ""


### PR DESCRIPTION
## Summary

- Fix `aap_setup_install` hostname defaults to accept both dict and list types for `aap_setup_prep_inv_nodes`, resolving `'list object' has no attribute 'keys'` errors

## Changes

- `controller_hostname`, `ah_hostname`, `eda_hostname`, and `gateway_hostname` defaults now use Jinja2 `is mapping` test to detect whether the inventory node entry is a dict or list
- When it's a dict (from `aap_setup_prepare`), `.keys()` is used to extract the first hostname
- When it's a list (from `aap_configuration_template`), `[0]` is used directly

Closes #327

## Test plan

- [x] `ansible-lint` passes
- [x] `pre-commit` hooks pass
- [ ] `ansible-test sanity` passes
- [ ] Verified with dict-style inventory nodes (aap_setup_prepare)
- [ ] Verified with list-style inventory nodes (aap_configuration_template)
- [x] Changelog fragment added

Made with [Cursor](https://cursor.com)