### PR TITLE
fix(role): default validate_certs to false in containerized wait tasks

### DIFF
--- a/changelogs/fragments/fix-containerized-wait-ssl.yml
+++ b/changelogs/fragments/fix-containerized-wait-ssl.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - "aap_setup_install - fix containerized wait tasks failing with ``CERTIFICATE_VERIFY_FAILED`` by defaulting ``validate_certs`` to ``false`` instead of ``omit``, matching the pre-check tasks (https://github.com/redhat-cop/aap_utilities/issues/319)."
+...

--- a/roles/aap_setup_install/tasks/containerized.yml
+++ b/roles/aap_setup_install/tasks/containerized.yml
@@ -82,14 +82,14 @@
       # these will always run and will always report "changed" otherwise
 
     - name: containerized | Wait for automation controller to be running
-      ansible.builtin.uri: # use the first host from the list if no hostname is defined
+      ansible.builtin.uri:
         url: https://{{ controller_hostname }}:{{ __aap_setup_inst_controller_port }}/api/
         method: GET
         user: admin
         password: "{{ aap_setup_prep_inv_secrets.all.controller_admin_password | default(aap_setup_prep_inv_vars.all.controller_admin_password) }}"
         force_basic_auth: true
         status_code: 200
-        validate_certs: "{{ controller_validate_certs | default(omit) }}"
+        validate_certs: "{{ controller_validate_certs | default('false') }}"
       register: __aap_setup_inst_result
       until: __aap_setup_inst_result.status == 200
       retries: 90
@@ -97,14 +97,14 @@
       when: "'automationcontroller' in aap_setup_prep_inv_nodes"
 
     - name: containerized | Wait for automation hub to be running
-      ansible.builtin.uri: # use the first host from the list if no hostname is defined
+      ansible.builtin.uri:
         url: https://{{ ah_hostname }}:{{ __aap_setup_inst_hub_port }}/api/galaxy/
         method: GET
         user: admin
         password: "{{ aap_setup_prep_inv_secrets.all.hub_admin_password | default(aap_setup_prep_inv_vars.all.hub_admin_password) }}"
         force_basic_auth: true
         status_code: 200
-        validate_certs: "{{ ah_validate_certs | default(omit) }}"
+        validate_certs: "{{ ah_validate_certs | default('false') }}"
       register: __aap_setup_inst_result_ah
       until: __aap_setup_inst_result_ah.status == 200
       retries: 90


### PR DESCRIPTION
## Summary

- Fix containerized post-install wait tasks failing with `CERTIFICATE_VERIFY_FAILED` when using self-signed certificates

## Changes

- Change `validate_certs` default from `omit` (which means `true`) to `'false'` in the "Wait for automation controller to be running" and "Wait for automation hub to be running" tasks in `containerized.yml`
- This aligns the wait tasks with the pre-check tasks (lines 8, 23, 38) that already correctly default to `'false'`
- The EDA wait task already used `default('false')` and was not affected

The root cause is that Ansible's `uri` module defaults `validate_certs` to `true` when the parameter is omitted. Since containerized AAP installations typically use installer-generated self-signed certificates, the health check retries all 90 times before failing.

Closes #319

## Test plan

- [x] `ansible-lint` passes
- [x] `pre-commit` hooks pass
- [ ] `ansible-test sanity` passes
- [ ] Verified with containerized AAP installation using self-signed certs
- [x] Changelog fragment added

Made with [Cursor](https://cursor.com)