### PR TITLE
fix(role): kill lingering processes before user removal in aap_remove

### DIFF
--- a/changelogs/fragments/fix-remove-user-processes.yml
+++ b/changelogs/fragments/fix-remove-user-processes.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - "aap_remove - kill lingering processes owned by service users before attempting user removal, preventing ``userdel: user is currently used by process`` failures (https://github.com/redhat-cop/aap_utilities/issues/254)."
+...

--- a/roles/aap_remove/tasks/ah_remove.yml
+++ b/roles/aap_remove/tasks/ah_remove.yml
@@ -46,6 +46,18 @@
     - /root/hub
   become: true
 
+- name: ah_remove | Kill remaining processes for users to be removed
+  ansible.builtin.command:
+    cmd: "killall -u {{ item }}"
+  loop:
+    - postgres
+    - redis
+    - pulp
+    - nginx
+  become: true
+  failed_when: false
+  changed_when: false
+
 - name: ah_remove | Remove added users
   ansible.builtin.user:
     name: "{{ item }}"

--- a/roles/aap_remove/tasks/controller_remove.yml
+++ b/roles/aap_remove/tasks/controller_remove.yml
@@ -43,6 +43,19 @@
     - /var/lib/automation-platform-bundle
   become: true
 
+- name: controller_remove | Kill remaining processes for users to be removed
+  ansible.builtin.command:
+    cmd: "killall -u {{ item }}"
+  loop:
+    - postgres
+    - redis
+    - nginx
+    - awx
+    - receptor
+  become: true
+  failed_when: false
+  changed_when: false
+
 - name: controller_remove | Remove added users
   ansible.builtin.user:
     name: "{{ item }}"


### PR DESCRIPTION
## Summary

- Fix `aap_remove` role failing at "Remove added users" when service processes are still running under those user accounts

## Changes

- Add a `killall -u <user>` task before user removal in both `controller_remove.yml` and `ah_remove.yml`
- The task uses `failed_when: false` since the user may not have any running processes (or may not exist)
- Affects both controller removal (postgres, redis, nginx, awx, receptor) and hub removal (postgres, redis, pulp, nginx)

### Root cause

After stopping systemd services, some processes (e.g., systemd user slices, lingering daemons) may still be running under service accounts like `awx`. The `ansible.builtin.user` module's `force: true` parameter is supposed to handle this, but on some RHEL versions `userdel` still fails with `rc=8` ("user is currently used by process"). Explicitly killing all processes for the user before removal resolves this reliably.

Closes #254

## Test plan

- [x] `ansible-lint` passes
- [x] `pre-commit` hooks pass
- [ ] `ansible-test sanity` passes
- [ ] Verified on RHEL 8/9 with running AWX processes
- [x] Changelog fragment added

Made with [Cursor](https://cursor.com)