### PR TITLE
fix(role): improve installer filename matching in aap_setup_download

### DIFF
--- a/changelogs/fragments/fix-download-type-filter.yml
+++ b/changelogs/fragments/fix-download-type-filter.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - "aap_setup_download - fix installer filename filtering to precisely match the requested type (``setup`` vs ``setup-bundle``), preventing type cross-contamination and ensuring all available versions are returned (https://github.com/redhat-cop/aap_utilities/issues/328)."
+...

--- a/changelogs/fragments/fix-download-type-filter.yml
+++ b/changelogs/fragments/fix-download-type-filter.yml
@@ -1,4 +1,5 @@
 ---
 bugfixes:
   - "aap_setup_download - fix installer filename filtering to precisely match the requested type (``setup`` vs ``setup-bundle``), preventing type cross-contamination and ensuring all available versions are returned (https://github.com/redhat-cop/aap_utilities/issues/328)."
+  - "increased the limit of images from 25 to 100 on the API request to ensure that latest version will be pulled"
 ...

--- a/roles/aap_setup_download/tasks/main.yml
+++ b/roles/aap_setup_download/tasks/main.yml
@@ -22,9 +22,12 @@
 
 - name: Select the Specified installer to download
   ansible.builtin.set_fact:
-    __aap_setup_down_images: "{{ __aap_setup_down_output.json.body | selectattr('filename', 'match', ((aap_setup_containerized | bool) | ternary('ansible-automation-platform-containerized-setup',
-      'ansible-automation-platform-setup'))) | sort(attribute='datePublished', reverse=True) | selectattr('filename', 'search', (aap_setup_down_type | string) + '-'
-      + (aap_setup_down_version | string)) }}"
+    __aap_setup_down_images: "{{ __aap_setup_down_output.json.body
+      | selectattr('filename', 'match', __aap_setup_down_filename_prefix)
+      | sort(attribute='datePublished', reverse=True) | list }}"
+  vars:
+    __aap_setup_down_filename_prefix: >-
+      {{ (aap_setup_containerized | bool) | ternary('ansible-automation-platform-containerized-', 'ansible-automation-platform-') }}{{ aap_setup_down_type }}-{{ aap_setup_down_version }}
 
 - name: Display all the filenames available for download
   ansible.builtin.debug:

--- a/roles/aap_setup_download/vars/main.yml
+++ b/roles/aap_setup_download/vars/main.yml
@@ -2,5 +2,5 @@
 # vars file for aap_setup_download
 aap_setup_down_release: ansible-automation-platform-{{ aap_setup_down_version }}-for-rhel-{{ aap_setup_rhel_version }}-{{ aap_setup_arch }}-files
 aap_setup_down_token_url: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
-aap_setup_down_images_url: https://api.access.redhat.com/management/v1/images/cset/{{ aap_setup_down_release }}
+aap_setup_down_images_url: https://api.access.redhat.com/management/v1/images/cset/{{ aap_setup_down_release }}?limit=100
 ...


### PR DESCRIPTION
## Summary

- Fix `aap_setup_download` installer type filtering to precisely match the requested type, preventing `setup` from also matching `setup-bundle` filenames and ensuring all available versions are returned

## Changes

- Replace the two-stage filter (broad prefix `match` then `search` for type+version) with a single precise `match` that combines the containerized prefix, download type, and version into one regex
- Previous behavior: `match('ansible-automation-platform-setup')` matched both `setup-2.6-6.tar.gz` AND `setup-bundle-2.6-3.tar.gz` since `match` only anchors at the start
- New behavior: `match('ansible-automation-platform-setup-2.6')` or `match('ansible-automation-platform-setup-bundle-2.6')` precisely selects only the requested type

### Example

With `aap_setup_down_type: setup-bundle` and `aap_setup_containerized: false`:
- **Before**: matched `ansible-automation-platform-setup-bundle-*` correctly, but the intermediate filter also pulled in non-bundle files
- **After**: single `match('ansible-automation-platform-setup-bundle-2.6')` returns only bundle files

Closes #328

## Test plan

- [x] `ansible-lint` passes
- [x] `pre-commit` hooks pass
- [ ] `ansible-test sanity` passes
- [ ] Verified with `aap_setup_down_type: setup-bundle` returns only bundle installers
- [ ] Verified with `aap_setup_down_type: setup` returns only non-bundle installers
- [x] Changelog fragment added

Made with [Cursor](https://cursor.com)