### PR TITLE
Update minimum ansible-core to 2.16 and improve README for validated certification

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,4 +117,4 @@ See [LICENSE](https://github.com/redhat-cop/aap_utilities/blob/devel/LICENSE) to
 
 ## Support
 
-As Red Hat Ansible Certified Content, this collection is entitled to support through the Ansible Automation Platform (AAP) using the **Create issue** button on the top right corner. If a support case cannot be opened with Red Hat and the collection has been obtained either from Galaxy or GitHub, there may community help available on the [Ansible Forum](https://forum.ansible.com/).
+This collection is [Ansible Validated Content](https://access.redhat.com/articles/3166901). It is reviewed and tested by Red Hat but is not supported under a Red Hat SLA. For reporting issues and requesting improvements, file an issue at the [AAP Utilities repository](https://github.com/redhat-cop/aap_utilities/issues). Community help is also available on the [Ansible Forum](https://forum.ansible.com/tag/infra-config-as-code).

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ The `aap_install_ocp` role requires the `kubernetes` (version 12.0.0 or later) P
 
 |                                      Collection Name                                                  |                      Purpose                      |
 |:-----------------------------------------------------------------------------------------------------:|:-------------------------------------------------:|
-| [AAP >= 2.5 Configuration](https://github.com/redhat-cop/infra.aap_configuration)                   | Ansible Automation Platform configuration |
-| [AAP <= 2.4 Controller Configuration](https://github.com/redhat-cop/infra.controller_configuration) | Automation controller configuration       |
+| [AAP >= 2.5 Configuration](https://github.com/redhat-cop/infra.aap_configuration)                     | Ansible Automation Platform configuration         |
+| [AAP <= 2.4 Controller Configuration](https://github.com/redhat-cop/infra.controller_configuration)   | Automation controller configuration               |
 | [AAP Configuration Extended](https://github.com/redhat-cop/aap_configuration_extended)                | Where other useful roles that don't fit here live |
 | [EE Utilities](https://github.com/redhat-cop/ee_utilities)                                            | Execution Environment creation utilities          |
 | [AAP Configuration Template](https://github.com/redhat-cop/aap_configuration_template)                | Configuration Template for this suite             |

--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ collections:
 
 ## Release and Upgrade Notes
 
+For details on changes between versions, please see
+[the changelog](https://github.com/redhat-cop/aap_utilities/blob/devel/CHANGELOG.rst).
+
 Many roles and variables have been renamed to reflect the product renaming from Tower to controller/AAP.
 Verify carefully your inventory variables and playbooks.
 
@@ -110,4 +113,8 @@ More information about contributing can be found in our [Contribution Guidelines
 
 GNU General Public License v3.0 or later.
 
-See [LICENSE](LICENSE) to see the full text.
+See [LICENSE](https://github.com/redhat-cop/aap_utilities/blob/devel/LICENSE) to see the full text.
+
+## Support
+
+As Red Hat Ansible Certified Content, this collection is entitled to support through the Ansible Automation Platform (AAP) using the **Create issue** button on the top right corner. If a support case cannot be opened with Red Hat and the collection has been obtained either from Galaxy or GitHub, there may community help available on the [Ansible Forum](https://forum.ansible.com/).

--- a/README.md
+++ b/README.md
@@ -40,20 +40,24 @@ The `aap_install_ocp` role requires the `kubernetes` (version 12.0.0 or later) P
 
 ## Links to Ansible Automation Platform Collections
 
-| Collection Name                                                                     | Purpose                       |
+|                                      Collection Name                                |            Purpose            |
 |:-----------------------------------------------------------------------------------:|:-----------------------------:|
-| [Ansible.controller repo](https://github.com/ansible/awx/tree/devel/awx_collection) | Automation controller modules |
-| [Ansible Hub Configuration](https://github.com/ansible/galaxy_collection)           | Automation hub configuration  |
+| [ansible.platform repo](https://github.com/ansible/ansible.platform)                | gateway/platform modules      |
+| [ansible.hub repo](https://github.com/ansible-collections/ansible_hub)              | Automation hub modules        |
+| [ansible.controller repo](https://github.com/ansible/awx/tree/devel/awx_collection) | Automation controller modules |
+| [ansible.eda repo](https://github.com/ansible/event-driven-ansible)                 | Event Driven Ansible modules  |
 
 ## Links to other Validated Configuration Collections for Ansible Automation Platform
 
-| Collection Name                                                                                     | Purpose                                   |
-|:---------------------------------------------------------------------------------------------------:|:-----------------------------------------:|
+|                                      Collection Name                                                  |                      Purpose                      |
+|:-----------------------------------------------------------------------------------------------------:|:-------------------------------------------------:|
 | [AAP >= 2.5 Configuration](https://github.com/redhat-cop/infra.aap_configuration)                   | Ansible Automation Platform configuration |
 | [AAP <= 2.4 Controller Configuration](https://github.com/redhat-cop/infra.controller_configuration) | Automation controller configuration       |
-| [EE Utilities](https://github.com/redhat-cop/ee_utilities)                                          | Execution Environment creation utilities  |
-| [AAP installation Utilities](https://github.com/redhat-cop/aap_utilities)                           | Ansible Automation Platform Utilities     |
-| [AAP Configuration Template](https://github.com/redhat-cop/aap_configuration_template)              | Configuration Template for this suite     |
+| [AAP Configuration Extended](https://github.com/redhat-cop/aap_configuration_extended)                | Where other useful roles that don't fit here live |
+| [EE Utilities](https://github.com/redhat-cop/ee_utilities)                                            | Execution Environment creation utilities          |
+| [AAP Configuration Template](https://github.com/redhat-cop/aap_configuration_template)                | Configuration Template for this suite             |
+| [Ansible Validated Gitlab Workflows](https://gitlab.com/redhat-cop/infra/ansible_validated_workflows) | Gitlab CI/CD Workflows for ansible content        |
+| [Ansible Validated GitHub Workflows](https://github.com/redhat-cop/infra.ansible_validated_workflows) | GitHub CI/CD Workflows for ansible content        |
 
 ## Included content
 

--- a/changelogs/fragments/certification-review-updates.yaml
+++ b/changelogs/fragments/certification-review-updates.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+  - README - Standardized collection links tables, added changelog link, converted LICENSE to absolute URL, and added Support section for certification review.
+  - meta/runtime.yml - Updated minimum ansible-core version from 2.15 to 2.16.

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,3 +1,3 @@
 ---
-requires_ansible: ">=2.15.0"
+requires_ansible: ">=2.16.0"
 ...


### PR DESCRIPTION
## Summary
- Update `requires_ansible` in `meta/runtime.yml` from `>=2.15.0` to `>=2.16.0` per AAP 2.4 lifecycle end
- Standardize "Links to Ansible Automation Platform Collections" table with current repos (ansible.platform, ansible.hub, ansible.controller, ansible.eda)
- Standardize "Links to other Validated Configuration Collections" table with all sibling collections
- Add changelog link in "Release and Upgrade Notes" section
- Convert relative `LICENSE` link to absolute GitHub URL
- Add Support section clarifying this is Ansible Validated Content

## Changes
- `meta/runtime.yml`: Bump minimum ansible-core version
- `README.md`: Updated both links tables, added changelog link, fixed LICENSE link, added Support section
- `changelogs/fragments/certification-review-updates.yaml`: Changelog fragment

## References
- [AAP ending support for ansible-core 2.15](https://forum.ansible.com/t/red-hat-ansible-automation-platform-is-ending-support-for-ansible-core-2-15-and-python-3-11/45574)

## Test plan
- [ ] Pre-commit checks pass
- [ ] Changelog fragment added in `changelogs/fragments/`
- [ ] `ansible-test sanity` passes against Core 2.16 + Python 3.12
- [ ] README renders correctly on GitHub