### PR TITLE
feat(aap_ocp_install): support platform component_deployment unified vs individual

### DIFF
--- a/changelogs/fragments/aap_ocp_install-component_deployment.yml
+++ b/changelogs/fragments/aap_ocp_install-component_deployment.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - >-
+    aap_ocp_install - add ``aap_ocp_install_platform.component_deployment`` for unified versus
+    individual Ansible Automation Platform 2.5+ installs on OpenShift.

--- a/roles/aap_ocp_install/README.md
+++ b/roles/aap_ocp_install/README.md
@@ -1,192 +1,194 @@
 # infra.aap_utilities.aap_ocp_install
 
-A role to install Ansible Automation Platform (AAP) 2.x on OpenShift using the operator.
+## Summary
+
+Installs Ansible Automation Platform (AAP) on OpenShift using the operator: connects to the OpenShift cluster, optionally creates the target namespace, installs the operator Subscription, then deploys your chosen components. Before any cluster changes, the role runs pre-flight checks and fails with a list of validation errors if something is wrong.
+
+For operator channels below 2.5, the role creates standalone `AutomationController`, `AutomationHub`, and `EDA` custom resources. For channels 2.5 and later, define `aap_ocp_install_platform` and set **`aap_ocp_install_platform.component_deployment`** to **`unified`** (default) to apply one `AnsibleAutomationPlatform` CR, or to **`individual`** to create standalone component CRs first and then link them from the platform CR. Optional `aap_ocp_install_controller`, `aap_ocp_install_hub`, and `aap_ocp_install_eda` dictionaries can be omitted when you are not configuring that component.
 
 ## Requirements
 
 - **Ansible:** 2.15.0 or later.
-- **Python:** the `kubernetes` module (version 12.0.0 or later).
-- **Ansible collections:** `kubernetes.core` and `redhat.openshift`.
+- **Python:** the `kubernetes` library (version 12.0.0 or later).
+- **Operator channel naming:** use a channel string that includes a `major.minor` version (for example `stable-2.4` or `stable-2.5-cluster-scoped`) so the role can tell pre-2.5 installs from 2.5+ platform installs.
 
-## Tags
+## Dependencies
 
-This role defines the following tags:
+Install these Ansible collections on the control node:
 
-| Tag | Purpose |
-| --- | ------- |
-| `always` | OpenShift initialization and finalization (authentication, validation, namespace setup where applicable, and finalization). Runs whenever the role runs. |
-| `operator` | Install the AAP operator when `aap_ocp_install_operator` is defined. |
-| `platform` | AAP 2.5+ only: build and apply the `AnsibleAutomationPlatform` CR when `aap_ocp_install_platform` is defined and the operator channel resolves to 2.5 or later. |
-| `controller` | Pre-2.5 only: standalone Automation Controller install when `aap_ocp_install_controller` is defined and the channel is below 2.5. On 2.5+, this path is skipped; use `platform` and `aap_ocp_install_platform` plus optional controller overrides. |
-| `hub` | Pre-2.5 only: standalone Hub install. On 2.5+, skipped in favor of the platform path; see `platform` and hub overrides. |
-| `eda` | Pre-2.5 only: standalone EDA install. On 2.5+, skipped in favor of the platform path; see `platform` and EDA overrides. |
+- `kubernetes.core`.
+- `redhat.openshift`.
 
-## Role Variables
+## Role variables
 
-The tables below document user-facing variables and nested keys.
+The tables below list user-facing variables and nested keys.
 
-| Variable Name                                  | Required   | Default Value   | Description                                                                                                |
-| ---------------------------------------------- | :--------: | --------------- | ----------------------------------------------------------------------------------------------             |
-| aap_ocp_install_namespace                      | Yes        |                 | Namespace to create operator, controller, and hub in                                                       |
-| aap_ocp_install_create_namespace               | No         | true            | Create the Namespace for the operator, controller and hub. Valid values are: `true`, `false`               |
-| aap_ocp_install_namespace_manifest_overrides   | No         |                 | YAML mapping merged into the generated default `Namespace` when `aap_ocp_install_create_namespace` is true |
-| aap_ocp_install_connection                     | Yes        |                 | Dictionary containing keys defined in the `connection variables table`                                     |
-| aap_ocp_install_operator                       | Yes*       |                 | Dictionary containing keys defined in the `operator variables table`                                       |
-| aap_ocp_install_controller                     | Yes*       |                 | Dictionary containing keys defined in the `controller variables table`                                     |
-| aap_ocp_install_hub                            | Yes*       |                 | Dictionary containing keys defined in the `hub variables table`                                            |
-| aap_ocp_install_eda                            | Yes*       |                 | Dictionary containing keys defined in the `eda variables table`                                            |
-| aap_ocp_install_platform                       | Yes*       |                 | Dictionary containing keys defined in the `platform variables table`                                       |
-| aap_ocp_install_lightspeed                     | No         |                 | Dictionary containing keys defined in the `lightspeed variables table`                                     |
+| Variable Name                                  | Required | Default Value | Description                                                                                                              |
+| :--------------------------------------------- | :------: | :------------ | :----------------------------------------------------------------------------------------------------------------------- |
+| `aap_ocp_install_namespace`                    | Yes      |               | Namespace for the operator Subscription and CSV; default namespace for components when their own `namespace` is not set. |
+| `aap_ocp_install_create_namespace`             | No       | `true`        | Whether to create `aap_ocp_install_namespace`. Valid values: `true`, `false`.                                            |
+| `aap_ocp_install_namespace_manifest_overrides` | No       |               | YAML mapping merged into the generated `Namespace` CR when `aap_ocp_install_create_namespace` is true.                   |
+| `aap_ocp_install_connection`                   | Yes      |               | Connection settings; see [Connection keys](#connection-keys-aap_ocp_install_connection).                                 |
+| `aap_ocp_install_operator`                     | Yes\*    |               | Operator install; see [Operator keys](#operator-keys-aap_ocp_install_operator).                                          |
+| `aap_ocp_install_controller`                   | Yes\*    |               | Controller; see [Controller keys](#controller-keys-aap_ocp_install_controller).                                          |
+| `aap_ocp_install_hub`                          | Yes\*    |               | Hub; see [Hub keys](#hub-keys-aap_ocp_install_hub).                                                                      |
+| `aap_ocp_install_eda`                          | Yes\*    |               | EDA; see [EDA keys](#eda-keys-aap_ocp_install_eda).                                                                      |
+| `aap_ocp_install_platform`                     | Yes\*    |               | AAP 2.5+ Platform; see [Platform keys](#platform-keys-aap_ocp_install_platform).                                         |
+| `aap_ocp_install_lightspeed`                   | No       |               | AAP 2.5+ Lightspeed; see [Lightspeed keys](#lightspeed-keys-aap_ocp_install_lightspeed).                                 |
 
-\* **Pre-2.5 (operator channel below 2.5):** When you limit the play with `--tags`, define the variable dictionary for each component you run (for example `--tags controller` requires `aap_ocp_install_controller`). If a component's variable is omitted, that component is not installed. If `aap_ocp_install_operator` is omitted, the operator is not installed.
+\* **Pre-2.5 (operator channel below 2.5):** When you limit the play with `--tags`, define the variable dictionary for each component you run (for example `--tags controller` requires `aap_ocp_install_controller`). If a component variable is omitted, that component is not installed. If `aap_ocp_install_operator` is omitted, the operator is not installed.
 
-\* **AAP 2.5+ (operator channel 2.5 or later):** The unified install runs under the `platform` tag. The `controller`, `hub`, and `eda` tags do **not** run the standalone component installers; set `aap_ocp_install_platform` and use `aap_ocp_install_controller`, `aap_ocp_install_hub`, and `aap_ocp_install_eda` for `install` flags and manifest overrides as documented below.
+\* **AAP 2.5+ (operator channel 2.5 or later):** Set `aap_ocp_install_platform` and choose **`component_deployment`** (see [Platform keys](#platform-keys-aap_ocp_install_platform)). With **`unified`** (default), the role applies one `AnsibleAutomationPlatform` CR with embedded component specs; use the `platform` tag and component dictionaries for `install` and overrides only (no standalone component CRs from this role). With **`individual`**, set `install` on each component you want, use the same namespace as the platform for those components, and run **`controller`**, **`hub`**, **`eda`**, and **`platform`** together so standalone CRs exist before the Platform CR links them by name (see Red Hat documentation for AAP custom resources).
 
-`aap_ocp_install_platform` and `aap_ocp_install_lightspeed` apply only when installing AAP 2.5 or later.
+`aap_ocp_install_platform` and `aap_ocp_install_lightspeed` apply only when the operator channel resolves to AAP 2.5 or later.
 
-### aap_ocp_install_connection keys
+### Connection keys (`aap_ocp_install_connection`)
 
-| Key Name       | Required | Default Value | Description                                                  |
-|----------------|:--------:|---------------|--------------------------------------------------------------|
-| host           |   Yes    |               | OCP cluster to create the AAP objects in                     |
-| username       |   Yes*   |               | Username to use for authenticating with OCP                  |
-| password       |   Yes*   |               | Password to use for authenticating with OCP                  |
-| api_key        |   Yes*   |               | OCP API Token                                                |
-| validate_certs |          |               | Validate SSL certificates. Valid values are: `true`, `false` |
+| Key Name         | Required | Default | Description                                                     |
+| :--------------- | :------: | :------ | :-------------------------------------------------------------- |
+| `host`           | Yes      |         | OpenShift API URL.                                              |
+| `username`       | Yes\*    |         | User name for cluster login.                                    |
+| `password`       | Yes\*    |         | Password for cluster login.                                     |
+| `api_key`        | Yes\*    |         | API token (do not set `username` / `password` when using this). |
+| `validate_certs` | No       |         | Whether to verify TLS. Valid values: `true`, `false`.           |
 
-\* Either `api_key` or `username` and `password` can be specified.
+\* Either `api_key`, or both `username` and `password`, must be set.
 
-### aap_ocp_install_operator keys
+### Operator keys (`aap_ocp_install_operator`)
 
-| Key Name                         | Required | Default Value | Description                                                                    |
-|----------------------------------|:--------:|---------------|--------------------------------------------------------------------------------|
-| channel                          |   Yes*   |               | Channel to subscribe (e.g. stable-2.5 or stable-2.5-cluster-scoped)            |
-| approval                         |          | Automatic     | Update approval method. Valid values are Automatic or Manual.                  |
-| starting_csv                     |          |               | Set the starting ClusterServiceVersion (e.g. aap-operator.v2.5.0-0.1728520175) |
-| operatorgroup_create             |          | true          | Create the `OperatorGroup` for the Operator                                    |
-| operatorgroup_manifest_overrides |          |               | YAML Manifest to override the generated `OperatorGroup` resource               |
-| subscription_manifest_overrides  |          |               | YAML Manifest to override the generated `Subscription` resource                |
+| Key Name                           | Required | Default     | Description                                                                                                                              |
+| :--------------------------------- | :------: | :---------- | :--------------------------------------------------------------------------------------------------------------------------------------- |
+| `channel`                          | Yes\*    |             | Catalog channel (for example `stable-2.5-cluster-scoped`).                                                                               |
+| `approval`                         | No       | `automatic` | Whether catalog updates install without extra steps (`automatic`) or stop for your approval before the operator install runs (`manual`). |
+| `starting_csv`                     | No       |             | Pin the starting `ClusterServiceVersion` if needed.                                                                                      |
+| `operatorgroup_create`             | No       | `true`      | Whether to create the `OperatorGroup`.                                                                                                   |
+| `operatorgroup_manifest_overrides` | No       |             | YAML mapping merged into the generated `OperatorGroup`.                                                                                  |
+| `subscription_manifest_overrides`  | No       |             | YAML mapping merged into the generated `Subscription`.                                                                                   |
 
-\* If the channel indicates version 2.5 or above of AAP, then the AAP operator platform installation method will be used.
+\* If the channel indicates AAP 2.5 or above, the 2.5+ platform installation path is used when `aap_ocp_install_platform` is defined.
 
-### aap_ocp_install_controller keys
+### Controller keys (`aap_ocp_install_controller`)
 
-| Key Name                         | Required   | Default Value                             | Description                                                                                                                             |
-| -------------------------------- | :--------: | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------                |
-| instance_name                    | Yes        |                                           | Name of the controller instance to create                                                                                               |
-| namespace                        |            |                                           | Name of the namespace to create the controller instance in. If not specified `aap_ocp_install_namespace` will be used.                  |
-| namespace_manifest_overrides     |            |                                           | YAML Manifest to override the generated `Namespace` resource for the controller if the `namespace` key is defined                       |
-| admin_user                       |            | admin                                     | Username to use for the admin account                                                                                                   |
-| replicas                         |            | 1                                         | How many replicas to create.                                                                                                            |
-| garbage_collect_secrets          |            | false                                     | Whether or not to remove secrets upon instance removal                                                                                  |
-| image_pull_policy                |            | IfNotPresent                              | The image pull policy                                                                                                                   |
-| create_preload_data              |            | true                                      | Whether or not to preload data upon instance creation                                                                                   |
-| projects_persistence             |            | false                                     | Whether or not the /var/lib/projects directory will be persistent                                                                       |
-| projects_storage_size            |            | 8Gi                                       | Size of /var/lib/projects persistent volume claim (PVC)                                                                                 |
-| controller_manifest_overrides    |            |                                           | YAML mapping merged into the `AutomationController` CR (pre-2.5) or into `spec.controller` on the `AnsibleAutomationPlatform` CR (2.5+) |
-| consolelink_manifest_overrides   |            |                                           | YAML mapping merged into the generated `ConsoleLink` for the controller (pre-2.5 only; not used on the platform install path)           |
-| create_link                      |            | true                                      | Create an OCP console application link (i.e. apply ConsoleLink CR)                                                                      |
-| link_text                        |            | Automation Controller (<INSTANCE_NAME>)   | Text used when creating the OCP console application link                                                                                |
-| install                          | *          | false                                     | Whether or not to install the Controller platform component in AAP 2.5 or later                                                         |
+| Key Name                         | Required | Default Value                             | Description                                                                                                                                                                                                                                                                                                          |
+| :------------------------------- | :------: | :---------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `instance_name`                  | Yes      |                                           | Controller custom resource name (required when this component is installed pre-2.5 or in **individual** 2.5+).                                                                                                                                                                                                       |
+| `namespace`                      | No       |                                           | Namespace for the controller CR; defaults to `aap_ocp_install_namespace`.                                                                                                                                                                                                                                            |
+| `namespace_manifest_overrides`   | No       |                                           | YAML mapping merged into the generated `Namespace` when `namespace` is set.                                                                                                                                                                                                                                          |
+| `admin_user`                     | No       | `admin`                                   | Admin account user name.                                                                                                                                                                                                                                                                                             |
+| `replicas`                       | No       | `1`                                       | Number of replicas.                                                                                                                                                                                                                                                                                                  |
+| `garbage_collect_secrets`        | No       | `false`                                   | Remove secrets when the instance is removed.                                                                                                                                                                                                                                                                         |
+| `image_pull_policy`              | No       | `IfNotPresent`                            | Container image pull policy.                                                                                                                                                                                                                                                                                         |
+| `create_preload_data`            | No       | `true`                                    | Preload default data on create.                                                                                                                                                                                                                                                                                      |
+| `projects_persistence`           | No       | `false`                                   | When `true`, persist `/var/lib/projects` on a PVC. The controller defaults to **ReadWriteMany** access so every replica can use the same directory; use a StorageClass that supports it, or set `projects_storage_access_mode` (and related fields) through `controller_manifest_overrides` if your storage differs. |
+| `projects_storage_size`          | No       | `8Gi`                                     | PVC capacity for the persistent projects volume when `projects_persistence` is `true`.                                                                                                                                                                                                                               |
+| `controller_manifest_overrides`  | No       |                                           | YAML merged into the `AutomationController` CR (pre-2.5 or **individual** standalone CR only). On **unified** 2.5+, merged into `spec.controller` on the `AnsibleAutomationPlatform` CR; not merged into the platform CR in **individual** mode (adoption uses `name` only).                                         |
+| `consolelink_manifest_overrides` | No       |                                           | YAML merged into the controller `ConsoleLink` (pre-2.5 only; not used when `aap_ocp_install_platform` is used on AAP 2.5+).                                                                                                                                                                                          |
+| `create_link`                    | No       | `true`                                    | Whether to create the OpenShift console `ConsoleLink`.                                                                                                                                                                                                                                                               |
+| `link_text`                      | No       | `Automation Controller (<INSTANCE_NAME>)` | Console link label.                                                                                                                                                                                                                                                                                                  |
+| `install`                        | \*       | `false`                                   | On AAP 2.5+, whether the controller component is enabled on the platform.                                                                                                                                                                                                                                            |
 
-\* These settings are only used for installing AAP 2.5 or later.
+\* Used for AAP 2.5 or later only.
 
-> ℹ️ **NOTE**
->
-> The namespace, instance_name and link_text values will be ignored when using the platform installation method. On AAP 2.5+, `controller_manifest_overrides` is merged into `spec.controller` on the `AnsibleAutomationPlatform` CR. Per-component `consolelink_manifest_overrides` is only used on the pre-2.5 install path; on 2.5+ use `aap_ocp_install_platform.consolelink_manifest_overrides` for the platform ConsoleLink.
+> **Note (AAP 2.5+):** On **unified** deployment, `namespace`, `instance_name`, and `link_text` are not used for gateway-managed controller layout; `controller_manifest_overrides` still merges into `spec.controller` on the `AnsibleAutomationPlatform` CR. On **individual** deployment, `controller_manifest_overrides` applies only to the standalone `AutomationController` CR; the platform CR keeps adoption-style `spec.controller` (`name` / `disabled`). Use `aap_ocp_install_platform.platform_manifest_overrides` to patch the platform CR itself. Per-component `consolelink_manifest_overrides` applies only pre-2.5; with `aap_ocp_install_platform` on 2.5+, only `aap_ocp_install_platform.consolelink_manifest_overrides` applies for the platform console link.
 
-### aap_ocp_install_hub keys
+### Hub keys (`aap_ocp_install_hub`)
 
-| Key Name                         | Required   | Default Value                      | Description                                                                                                               |
-| -------------------------------- | :--------: | ---------------------------------- | -----------------------------------------------------------------------------------------------------------------         |
-| instance_name                    | Yes        |                                    | Name of the hub instance to create                                                                                        |
-| namespace                        |            |                                    | Name of the namespace to create the hub instance in. If not specified `aap_ocp_install_namespace` will be used.           |
-| namespace_manifest_overrides     |            |                                    | YAML Manifest to override the generated `Namespace` resource for the hub if the `namespace` key is defined                |
-| hub_manifest_overrides           |            |                                    | YAML mapping merged into the `AutomationHub` CR (pre-2.5) or into `spec.hub` on the `AnsibleAutomationPlatform` CR (2.5+) |
-| consolelink_manifest_overrides   |            |                                    | YAML mapping merged into the generated `ConsoleLink` for the hub (pre-2.5 only; not used on the platform install path)    |
-| storage_type                     | *          | file                               | Hub storage type: `file`, `S3` (capital **S3**), or `azure`                                                               |
-| file_storage_storage_class       | *          |                                    | OpenShift StorageClass to use for file storage type for hub                                                               |
-| file_storage_size                | *          | 10Gi                               | Storage size for file storage type for hub                                                                                |
-| object_storage_s3_secret         | *          |                                    | Name of an OpenShift Secret used to access S3 storage for hub                                                             |
-| object_storage_azure_secret      | *          |                                    | Name of an OpenShift Secret used to access Azure storage for hub                                                          |
-| create_link                      |            | true                               | Create an OCP console application link (i.e. apply ConsoleLink CR)                                                        |
-| link_text                        |            | Automation Hub (<INSTANCE_NAME>)   | Text used for creating the OCP application link                                                                           |
-| install                          | *          | false                              | Whether or not to install the Hub platform component in AAP 2.5 or later                                                  |
+| Key Name                         | Required | Default Value                      | Description                                                                                                                                                                                                     |
+| :------------------------------- | :------: | :--------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `instance_name`                  | Yes      |                                    | Hub custom resource name.                                                                                                                                                                                       |
+| `namespace`                      | No       |                                    | Namespace for the hub CR; defaults to `aap_ocp_install_namespace`.                                                                                                                                              |
+| `namespace_manifest_overrides`   | No       |                                    | YAML mapping merged into the generated `Namespace` when `namespace` is set.                                                                                                                                     |
+| `hub_manifest_overrides`         | No       |                                    | YAML merged into the `AutomationHub` CR (pre-2.5 or **individual** standalone CR only). On **unified** 2.5+, merged into `spec.hub` on the platform CR; not merged into the platform CR in **individual** mode. |
+| `consolelink_manifest_overrides` | No       |                                    | YAML merged into the hub `ConsoleLink` (pre-2.5 only; not used when `aap_ocp_install_platform` is used on AAP 2.5+).                                                                                            |
+| `storage_type`                   | \*       | `file`                             | `file`, `S3` (capital **S3**), or `azure`.                                                                                                                                                                      |
+| `file_storage_storage_class`     | \*       |                                    | StorageClass for file-backed hub (when `storage_type` is `file`).                                                                                                                                               |
+| `file_storage_size`              | \*       | `10Gi`                             | PVC size for file-backed hub.                                                                                                                                                                                   |
+| `object_storage_s3_secret`       | \*       |                                    | Secret name for S3-backed hub.                                                                                                                                                                                  |
+| `object_storage_azure_secret`    | \*       |                                    | Secret name for Azure-backed hub.                                                                                                                                                                               |
+| `create_link`                    | No       | `true`                             | Whether to create the hub `ConsoleLink`.                                                                                                                                                                        |
+| `link_text`                      | No       | `Automation Hub (<INSTANCE_NAME>)` | Console link label.                                                                                                                                                                                             |
+| `install`                        | \*       | `false`                            | On AAP 2.5+, whether the hub component is enabled on the platform.                                                                                                                                              |
 
-\* These settings are only used for installing AAP 2.5 or later.
+\* Used for AAP 2.5 or later only.
 
-> ℹ️ **NOTE**
->
-> The namespace, instance_name and link_text values will be ignored when using the platform installation method. On AAP 2.5+, `hub_manifest_overrides` is merged into `spec.hub` on the `AnsibleAutomationPlatform` CR.
+> **Note (AAP 2.5+):** On **unified** deployment, `namespace`, `instance_name`, and `link_text` are not used for gateway-managed hub; `hub_manifest_overrides` merges into `spec.hub`. On **individual** deployment, `instance_name` and namespace (must match the platform namespace) apply to the standalone hub CR and to `spec.hub.name` on the platform CR.
 
-### aap_ocp_install_eda keys
+### EDA keys (`aap_ocp_install_eda`)
 
-| Key Name                         | Required   | Default Value                      | Description                                                                                                        |
-| -------------------------------- | :--------: | ---------------------------------- | -----------------------------------------------------------------------------------------------------------------  |
-| instance_name                    | Yes        |                                    | Name of the EDA instance to create                                                                                 |
-| namespace                        |            |                                    | Name of the namespace to create the EDA instance in. If not specified `aap_ocp_install_namespace` will be used.    |
-| namespace_manifest_overrides     |            |                                    | YAML Manifest to override the generated `Namespace` resource for the EDA if the `namespace` key is defined         |
-| eda_manifest_overrides           |            |                                    | YAML mapping merged into the `EDA` CR (pre-2.5) or into `spec.eda` on the `AnsibleAutomationPlatform` CR (2.5+)    |
-| consolelink_manifest_overrides   |            |                                    | YAML mapping merged into the generated `ConsoleLink` for EDA (pre-2.5 only; not used on the platform install path) |
-| create_link                      |            | true                               | Create an OCP console application link (i.e. apply ConsoleLink CR)                                                 |
-| link_text                        |            | EDA Controller (<INSTANCE_NAME>)   | Text used for creating the OCP application link                                                                    |
-| install                          | *          | false                              | Whether or not to install the EDA platform component in AAP 2.5 or later                                           |
+| Key Name                         | Required | Default Value                      | Description                                                                                                                                                                                           |
+| :------------------------------- | :------: | :--------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `instance_name`                  | Yes      |                                    | EDA custom resource name.                                                                                                                                                                             |
+| `namespace`                      | No       |                                    | Namespace for the EDA CR; defaults to `aap_ocp_install_namespace`.                                                                                                                                    |
+| `namespace_manifest_overrides`   | No       |                                    | YAML mapping merged into the generated `Namespace` when `namespace` is set.                                                                                                                           |
+| `eda_manifest_overrides`         | No       |                                    | YAML merged into the `EDA` CR (pre-2.5 or **individual** standalone CR only). On **unified** 2.5+, merged into `spec.eda` on the platform CR; not merged into the platform CR in **individual** mode. |
+| `consolelink_manifest_overrides` | No       |                                    | YAML merged into the EDA `ConsoleLink` (pre-2.5 only; not used when `aap_ocp_install_platform` is used on AAP 2.5+).                                                                                  |
+| `create_link`                    | No       | `true`                             | Whether to create the EDA `ConsoleLink`.                                                                                                                                                              |
+| `link_text`                      | No       | `EDA Controller (<INSTANCE_NAME>)` | Console link label.                                                                                                                                                                                   |
+| `install`                        | \*       | `false`                            | On AAP 2.5+, whether the EDA component is enabled on the platform.                                                                                                                                    |
 
-\* These settings are only used for installing AAP 2.5 or later.
+\* Used for AAP 2.5 or later only.
 
-> ℹ️ **NOTE**
->
-> The namespace, instance_name and link_text values will be ignored when using the platform installation method. On AAP 2.5+, `eda_manifest_overrides` is merged into `spec.eda` on the `AnsibleAutomationPlatform` CR.
+> **Note (AAP 2.5+):** On **unified** deployment, `namespace`, `instance_name`, and `link_text` are not used for gateway-managed EDA; `eda_manifest_overrides` merges into `spec.eda`. On **individual** deployment, `instance_name` and namespace (must match the platform namespace) apply to the standalone EDA CR and to `spec.eda.name` on the platform CR.
 
-### aap_ocp_install_platform keys
+### Platform keys (`aap_ocp_install_platform`)
 
-| Key Name                         | Required   | Default Value       | Description                                                                                                                |
-| -------------------------------- | :--------: | ------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| instance_name                    | Yes        |                     | Name of the AAP Platform instance to create                                                                                |
-| namespace                        |            |                     | Name of the namespace to create the AAP platform instance in. If not specified `aap_ocp_install_namespace` will be used.   |
-| namespace_manifest_overrides     |            |                     | YAML mapping merged into the generated `Namespace` resource when `namespace` is set                                        |
-| platform_manifest_overrides      |            |                     | YAML mapping deep-merged into the generated `AnsibleAutomationPlatform` CR (after rendering the template)                  |
-| consolelink_manifest_overrides   |            |                     | YAML mapping merged into the generated platform `ConsoleLink` resource                                                     |
-| create_link                      |            | true                | Create an OCP console application link (i.e. apply ConsoleLink CR)                                                         |
-| link_text                        |            | (<INSTANCE_NAME>)   | Text used for creating the platform OCP application link                                                                   |
+| Key Name                         | Required | Default Value       | Description                                                                                                                                                                                                                                                                                                      |
+| :------------------------------- | :------: | :------------------ | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `instance_name`                  | Yes      |                     | Name of the `AnsibleAutomationPlatform` CR.                                                                                                                                                                                                                                                                      |
+| `namespace`                      | No       |                     | Namespace for the platform CR; defaults to `aap_ocp_install_namespace`.                                                                                                                                                                                                                                          |
+| `component_deployment`           | No       | `unified`           | **`unified`:** one `AnsibleAutomationPlatform` CR with embedded `spec.controller` / `spec.hub` / `spec.eda`. **`individual`:** create standalone component CRs for each component with `install: true`, then apply the platform CR with `spec.<component>.name` pointing at those CRs (same namespace required). |
+| `namespace_manifest_overrides`   | No       |                     | YAML mapping merged into the generated platform `Namespace` when `namespace` is set.                                                                                                                                                                                                                             |
+| `platform_manifest_overrides`    | No       |                     | YAML mapping merged into the `AnsibleAutomationPlatform` CR.                                                                                                                                                                                                                                                     |
+| `consolelink_manifest_overrides` | No       |                     | YAML mapping merged into the platform `ConsoleLink`.                                                                                                                                                                                                                                                             |
+| `create_link`                    | No       | `true`              | Whether to create the platform `ConsoleLink`.                                                                                                                                                                                                                                                                    |
+| `link_text`                      | No       | `(<INSTANCE_NAME>)` | Console link label for the platform.                                                                                                                                                                                                                                                                             |
 
-> ℹ️ **NOTE**
->
-> These settings are only used when installing AAP 2.5 or later. Namespace, instance_name and link_text values for individual components (hub, controller, eda) are ignored when using the platform installation method; optional `controller_manifest_overrides`, `hub_manifest_overrides`, and `eda_manifest_overrides` on those component dictionaries are still merged into the unified CR (see **AAP 2.5+ manifest merge order** below).
+> **Note:** These keys apply only when installing AAP 2.5 or later. With **`unified`**, `namespace`, `instance_name`, and `link_text` on component dictionaries do not drive gateway layout; overrides still merge as described under [AAP 2.5+ manifest merge order](#aap-25-manifest-merge-order). With **`individual`**, each installed component's `instance_name` and effective namespace must match the standalone CRs and the platform namespace (operator requirement).
 
 #### AAP 2.5+ manifest merge order
 
 For the `AnsibleAutomationPlatform` CR, overrides are applied in this order:
 
-1. Render the `AnsibleAutomationPlatform` manifest from the role template.
-2. Deep-merge `aap_ocp_install_platform.platform_manifest_overrides` (optional cross-cutting patch).
-3. Deep-merge component-specific mappings into `spec` subtrees when the corresponding variable dictionary is defined:
+1. Build the base `AnsibleAutomationPlatform` manifest (component enable/disable and defaults).
+2. Merge `aap_ocp_install_platform.platform_manifest_overrides`.
+3. **`unified` mode only:** when the corresponding component dictionary is defined, merge component overrides into `spec` subtrees:
    - `aap_ocp_install_controller.controller_manifest_overrides` into `spec.controller`
    - `aap_ocp_install_hub.hub_manifest_overrides` into `spec.hub`
    - `aap_ocp_install_eda.eda_manifest_overrides` into `spec.eda`
 
-Later steps win on conflicting keys within the same subtree. The platform `Namespace` (when `namespace` is set) and platform `ConsoleLink` each support their own `*_manifest_overrides` keys on `aap_ocp_install_platform` as described in the table above.
+Later merges win on conflicting keys within the same subtree. The platform `Namespace` (when `namespace` is set) and platform `ConsoleLink` each use their own `*_manifest_overrides` keys on `aap_ocp_install_platform`, as listed in the platform table.
 
-For the unified `AnsibleAutomationPlatform` CR, component settings must appear under `spec.controller`, `spec.hub`, and `spec.eda` at the same nesting level the operator expects (see `oc explain ansibleautomationplatform.spec.<component>`). You may supply overrides in either form:
+With **`individual`** `component_deployment`, step 3 is skipped: the platform CR keeps adoption-style `spec.<component>` (`name` / `disabled` only). Component `*_manifest_overrides` apply only when creating the standalone component CRs. To adjust the platform CR under **individual**, use `platform_manifest_overrides` (use sparingly; see `oc explain ansibleautomationplatform.spec`).
 
-- **Platform shape (recommended):** keys that belong directly under `spec.<component>` (for example `postgres_configuration_secret` next to `replicas` and `disabled`).
-- **Standalone-CR shape (compatibility):** the same fields nested under a top-level `spec` key in the override mapping, as used when merging into a standalone `AutomationController` / `AutomationHub` / EDA CR. On the platform install path, that inner `spec` mapping is merged into `spec.<component>` instead of creating an invalid nested `spec.<component>.spec`.
+For **unified** installs, fields must match what the operator expects under `spec.controller`, `spec.hub`, and `spec.eda` (see `oc explain ansibleautomationplatform.spec.<component>`). Overrides may be supplied in either shape:
 
-### aap_ocp_install_lightspeed keys
+- **Platform shape (recommended):** keys that belong directly under `spec.<component>` (for example next to `replicas` and `disabled`).
+- **Standalone-CR shape (compatibility):** the same fields under a top-level `spec` key in the override mapping. On the platform path, that inner `spec` mapping is merged into `spec.<component>` instead of producing an invalid nested `spec.<component>.spec`.
 
-| Key Name | Required | Default Value | Description                                                  |
-|----------|:--------:|---------------|--------------------------------------------------------------|
-| install  | No       | false         | Whether or not to install the platform Lightspeed components |
+### Lightspeed keys (`aap_ocp_install_lightspeed`)
 
-> ℹ️ **NOTE**
->
-> These settings are only used when installing AAP 2.5 or later.
+| Key Name  | Required | Default | Description                                                         |
+| :-------- | :------: | :------ | :------------------------------------------------------------------ |
+| `install` | No       | `false` | When `true`, enables Lightspeed on the platform CR (AAP 2.5+ only). |
 
-## Example Playbook
+## Tags
 
-The following playbook will install AAP versions 2.4 and earlier:
+| Tag          | What runs                                                                                                                                                                                                                                                                          |
+| :----------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `always`     | Pre-validation, OpenShift authentication and connection check, optional top-level namespace creation, and finalization. Always evaluated when the role runs.                                                                                                                       |
+| `operator`   | Operator `OperatorGroup` and `Subscription` when `aap_ocp_install_operator` is defined.                                                                                                                                                                                            |
+| `platform`   | AAP 2.5+ only: create or update the `AnsibleAutomationPlatform` CR when `aap_ocp_install_platform` is defined and the channel resolves to 2.5+. When tagging this role, include this tag for a full 2.5+ platform apply.                                                           |
+| `controller` | Pre-2.5: standalone `AutomationController` when `aap_ocp_install_controller` is defined. AAP 2.5+ **unified:** skipped (settings feed the platform CR). AAP 2.5+ **individual:** runs when `install` is true for the controller; creates the standalone CR before the platform CR. |
+| `hub`        | Same pattern as `controller` for Automation Hub.                                                                                                                                                                                                                                   |
+| `eda`        | Same pattern as `controller` for EDA.                                                                                                                                                                                                                                              |
 
-```yml
+**Console links:** Per-component `ConsoleLink` objects are created for controller, hub, and EDA only when you are **not** on an AAP 2.5+ platform install (`aap_ocp_install_platform` defined with channel 2.5+). On 2.5+ platform installs, only the platform `ConsoleLink` is managed (when `aap_ocp_install_platform.create_link` is true). Tag the corresponding component or `platform` so those steps run when you use selective tags.
+
+## Example playbooks
+
+Pre-2.5 (for example channel `stable-2.2`):
+
+```yaml
 ---
 - name: Install AAP on OCP playbook
   hosts: localhost
@@ -212,9 +214,9 @@ The following playbook will install AAP versions 2.4 and earlier:
     - infra.aap_utilities.aap_ocp_install
 ```
 
-The following playbook will install AAP versions 2.5 and later:
+AAP 2.5+ (single namespace: omit `aap_ocp_install_platform.namespace` to use `aap_ocp_install_namespace`):
 
-```yml
+```yaml
 ---
 - name: Install AAP on OCP playbook 2.5+
   hosts: localhost
@@ -230,8 +232,7 @@ The following playbook will install AAP versions 2.5 and later:
     aap_ocp_install_operator:
       channel: "stable-2.5-cluster-scoped"
     aap_ocp_install_platform:
-      instance_name: automationcontroller
-      namespace: aap-platform
+      instance_name: aaptest
     aap_ocp_install_controller:
       install: true
     aap_ocp_install_eda:
@@ -246,11 +247,13 @@ The following playbook will install AAP versions 2.5 and later:
     - infra.aap_utilities.aap_ocp_install
 ```
 
+You may set `aap_ocp_install_platform.namespace` to a different valid namespace than `aap_ocp_install_namespace` if your layout requires it; the simple case is one shared namespace.
+
 ## License
 
 [GPLv3+0](https://github.com/redhat-cop/aap_utilities#licensing)
 
-## Author Information
+## Author information
 
 - Brant Evans
 - Derek Waters

--- a/roles/aap_ocp_install/defaults/main.yml
+++ b/roles/aap_ocp_install/defaults/main.yml
@@ -18,6 +18,7 @@
 # aap_ocp_install_platform:
 #   instance_name:
 #   namespace:
+#   component_deployment: unified   # unified (default) | individual — see role README
 #   namespace_manifest_overrides:
 #   platform_manifest_overrides:
 #   consolelink_manifest_overrides:

--- a/roles/aap_ocp_install/tasks/build-platform-cr.yml
+++ b/roles/aap_ocp_install/tasks/build-platform-cr.yml
@@ -1,7 +1,12 @@
 ---
 # Build the AnsibleAutomationPlatform CR: render platform/instance.yaml.j2, apply
 # platform_manifest_overrides, then merge per-component overrides into spec.controller,
-# spec.hub, and spec.eda.
+# spec.hub, and spec.eda for unified mode only.
+#
+# Individual mode: template emits adoption-style name/disabled only; component
+# *_manifest_overrides are applied solely on standalone CRs (install-*.yml), not merged
+# here—merging would duplicate AutomationController/AutomationHub/EDA fields onto the
+# Platform CR (e.g. task_replicas, hub storage, pulp_settings).
 #
 # Standalone component CRs use metadata + spec; for the unified platform CR, operator
 # fields live directly under spec.<component>. If *_manifest_overrides repeat the
@@ -9,7 +14,9 @@
 # sibling fields under spec.<component> (not as spec.<component>.spec).
 
 - name: build-platform-cr | Derive effective controller manifest overrides for platform CR
-  when: aap_ocp_install_controller is defined
+  when:
+    - aap_ocp_install_controller is defined
+    - (__aap_ocp_install_platform_component_deployment | default('unified')) != 'individual'
   ansible.builtin.set_fact:
     __aap_ocp_install_controller_manifest_for_platform: >-
       {{
@@ -26,7 +33,9 @@
       }}
 
 - name: build-platform-cr | Derive effective hub manifest overrides for platform CR
-  when: aap_ocp_install_hub is defined
+  when:
+    - aap_ocp_install_hub is defined
+    - (__aap_ocp_install_platform_component_deployment | default('unified')) != 'individual'
   ansible.builtin.set_fact:
     __aap_ocp_install_hub_manifest_for_platform: >-
       {{
@@ -43,7 +52,9 @@
       }}
 
 - name: build-platform-cr | Derive effective EDA manifest overrides for platform CR
-  when: aap_ocp_install_eda is defined
+  when:
+    - aap_ocp_install_eda is defined
+    - (__aap_ocp_install_platform_component_deployment | default('unified')) != 'individual'
   ansible.builtin.set_fact:
     __aap_ocp_install_eda_manifest_for_platform: >-
       {{
@@ -68,17 +79,23 @@
     __aap_ocp_install_platform_cr: "{{ __aap_ocp_install_platform_cr | ansible.builtin.combine(aap_ocp_install_platform['platform_manifest_overrides'] | default({}), recursive=true) }}"
 
 - name: build-platform-cr | Merge controller manifest overrides into spec.controller
-  when: aap_ocp_install_controller is defined
+  when:
+    - aap_ocp_install_controller is defined
+    - (__aap_ocp_install_platform_component_deployment | default('unified')) != 'individual'
   ansible.builtin.set_fact:
     __aap_ocp_install_platform_cr: "{{ __aap_ocp_install_platform_cr | ansible.builtin.combine({'spec': {'controller': __aap_ocp_install_platform_cr['spec']['controller'] | ansible.builtin.combine(__aap_ocp_install_controller_manifest_for_platform | default({}), recursive=true)}}, recursive=true) }}"
 
 - name: build-platform-cr | Merge hub manifest overrides into spec.hub
-  when: aap_ocp_install_hub is defined
+  when:
+    - aap_ocp_install_hub is defined
+    - (__aap_ocp_install_platform_component_deployment | default('unified')) != 'individual'
   ansible.builtin.set_fact:
     __aap_ocp_install_platform_cr: "{{ __aap_ocp_install_platform_cr | ansible.builtin.combine({'spec': {'hub': __aap_ocp_install_platform_cr['spec']['hub'] | ansible.builtin.combine(__aap_ocp_install_hub_manifest_for_platform | default({}), recursive=true)}}, recursive=true) }}"
 
 - name: build-platform-cr | Merge EDA manifest overrides into spec.eda
-  when: aap_ocp_install_eda is defined
+  when:
+    - aap_ocp_install_eda is defined
+    - (__aap_ocp_install_platform_component_deployment | default('unified')) != 'individual'
   ansible.builtin.set_fact:
     __aap_ocp_install_platform_cr: "{{ __aap_ocp_install_platform_cr | ansible.builtin.combine({'spec': {'eda': __aap_ocp_install_platform_cr['spec']['eda'] | ansible.builtin.combine(__aap_ocp_install_eda_manifest_for_platform | default({}), recursive=true)}}, recursive=true) }}"
 ...

--- a/roles/aap_ocp_install/tasks/consolelinks.yml
+++ b/roles/aap_ocp_install/tasks/consolelinks.yml
@@ -1,0 +1,61 @@
+---
+- name: consolelinks | Create automation controller console link
+  when:
+    - aap_ocp_install_controller is defined
+    - aap_ocp_install_controller['create_link'] | default(true) | bool
+    - not ((__aap_ocp_install_25_install | bool) and (aap_ocp_install_platform is defined))
+  tags:
+    - controller
+  kubernetes.core.k8s:
+    host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
+    api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
+    validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
+    state: present
+    resource_definition: "{{ lookup('ansible.builtin.template', 'controller/consolelink.yaml.j2') | from_yaml | ansible.builtin.combine(aap_ocp_install_controller['consolelink_manifest_overrides'] | default({}), recursive=true) }}"
+    apply: true
+
+- name: consolelinks | Create automation hub console link
+  when:
+    - aap_ocp_install_hub is defined
+    - aap_ocp_install_hub['create_link'] | default(true) | bool
+    - not ((__aap_ocp_install_25_install | bool) and (aap_ocp_install_platform is defined))
+  tags:
+    - hub
+  kubernetes.core.k8s:
+    host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
+    api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
+    validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
+    state: present
+    resource_definition: "{{ lookup('ansible.builtin.template', 'hub/consolelink.yaml.j2') | from_yaml | ansible.builtin.combine(aap_ocp_install_hub['consolelink_manifest_overrides'] | default({}), recursive=true) }}"
+    apply: true
+
+- name: consolelinks | Create EDA console link
+  when:
+    - aap_ocp_install_eda is defined
+    - aap_ocp_install_eda['create_link'] | default(true) | bool
+    - not ((__aap_ocp_install_25_install | bool) and (aap_ocp_install_platform is defined))
+  tags:
+    - eda
+  kubernetes.core.k8s:
+    host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
+    api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
+    validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
+    state: present
+    resource_definition: "{{ lookup('ansible.builtin.template', 'eda/consolelink.yaml.j2') | from_yaml | ansible.builtin.combine(aap_ocp_install_eda['consolelink_manifest_overrides'] | default({}), recursive=true) }}"
+    apply: true
+
+- name: consolelinks | Create automation platform console link
+  when:
+    - aap_ocp_install_platform is defined
+    - __aap_ocp_install_25_install | bool
+    - aap_ocp_install_platform['create_link'] | default(true) | bool
+  tags:
+    - platform
+  kubernetes.core.k8s:
+    host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
+    api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
+    validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
+    state: present
+    resource_definition: "{{ lookup('ansible.builtin.template', 'platform/consolelink.yaml.j2') | from_yaml | ansible.builtin.combine(aap_ocp_install_platform['consolelink_manifest_overrides'] | default({}), recursive=true) }}"
+    apply: true
+...

--- a/roles/aap_ocp_install/tasks/install-controller.yml
+++ b/roles/aap_ocp_install/tasks/install-controller.yml
@@ -54,15 +54,4 @@
     - ('migrations_notran' not in __aap_ocp_install_controller_available['url'])
   retries: 120 # Wait for 30 minutes (120*15/60)
   delay: 15
-
-- name: install-controller | Create automation controller console link
-  when:
-    - aap_ocp_install_controller['create_link'] | default(true) | bool
-  kubernetes.core.k8s:
-    host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
-    api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
-    validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
-    state: present
-    resource_definition: "{{ lookup('template', 'controller/consolelink.yaml.j2') | from_yaml | ansible.builtin.combine(aap_ocp_install_controller['consolelink_manifest_overrides'] | default({}), recursive=true) }}"
-    apply: true
 ...

--- a/roles/aap_ocp_install/tasks/install-eda.yml
+++ b/roles/aap_ocp_install/tasks/install-eda.yml
@@ -53,15 +53,4 @@
     - __aap_ocp_install_eda_available['status'] == 200
   retries: 120 # Wait for 30 minutes (120*15/60)
   delay: 15
-
-- name: install-eda | Create EDA console link
-  when:
-    - aap_ocp_install_eda['create_link'] | default(true) | bool
-  kubernetes.core.k8s:
-    host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
-    api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
-    validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
-    state: present
-    resource_definition: "{{ lookup('template', 'eda/consolelink.yaml.j2') | from_yaml | ansible.builtin.combine(aap_ocp_install_eda['consolelink_manifest_overrides'] | default({}), recursive=true) }}"
-    apply: true
 ...

--- a/roles/aap_ocp_install/tasks/install-hub.yml
+++ b/roles/aap_ocp_install/tasks/install-hub.yml
@@ -53,15 +53,4 @@
     - __aap_ocp_install_hub_available['status'] == 200
   retries: 120 # Wait for 30 minutes (120*15/60)
   delay: 15
-
-- name: install-hub | Create automation hub console link
-  when:
-    - aap_ocp_install_hub['create_link'] | default(true) | bool
-  kubernetes.core.k8s:
-    host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
-    api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
-    validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
-    state: present
-    resource_definition: "{{ lookup('template', 'hub/consolelink.yaml.j2') | from_yaml | ansible.builtin.combine(aap_ocp_install_hub['consolelink_manifest_overrides'] | default({}), recursive=true) }}"
-    apply: true
 ...

--- a/roles/aap_ocp_install/tasks/install-operator.yml
+++ b/roles/aap_ocp_install/tasks/install-operator.yml
@@ -40,7 +40,7 @@
 
 - name: install-operator | Update install plan
   when:
-    - (aap_ocp_install_operator['approval'] | default('Automatic') | lower) == 'manual'
+    - (aap_ocp_install_operator['approval'] | default('automatic') | lower) == 'manual'
   kubernetes.core.k8s:
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"

--- a/roles/aap_ocp_install/tasks/install-platform.yml
+++ b/roles/aap_ocp_install/tasks/install-platform.yml
@@ -65,6 +65,7 @@
     - aap_ocp_install_controller is defined
     - aap_ocp_install_controller['install'] is defined
     - aap_ocp_install_controller['install'] | bool
+    - not ((__aap_ocp_install_platform_component_deployment | default('unified')) == 'individual')
   kubernetes.core.k8s_info:
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
@@ -84,6 +85,7 @@
     - aap_ocp_install_controller is defined
     - aap_ocp_install_controller['install'] is defined
     - aap_ocp_install_controller['install'] | bool
+    - not ((__aap_ocp_install_platform_component_deployment | default('unified')) == 'individual')
   ansible.builtin.set_fact:
     aap_ocp_install_controller_route: "https://{{ __aap_ocp_install_controller_route_result['resources'][0]['status']['ingress'][0]['host'] }}"
 
@@ -92,6 +94,7 @@
     - aap_ocp_install_controller is defined
     - aap_ocp_install_controller['install'] is defined
     - aap_ocp_install_controller['install'] | bool
+    - not ((__aap_ocp_install_platform_component_deployment | default('unified')) == 'individual')
   ansible.builtin.uri:
     url: "{{ aap_ocp_install_controller_route }}/api"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
@@ -110,6 +113,7 @@
     - aap_ocp_install_eda is defined
     - aap_ocp_install_eda['install'] is defined
     - aap_ocp_install_eda['install'] | bool
+    - not ((__aap_ocp_install_platform_component_deployment | default('unified')) == 'individual')
   kubernetes.core.k8s_info:
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
@@ -129,6 +133,7 @@
     - aap_ocp_install_eda is defined
     - aap_ocp_install_eda['install'] is defined
     - aap_ocp_install_eda['install'] | bool
+    - not ((__aap_ocp_install_platform_component_deployment | default('unified')) == 'individual')
   ansible.builtin.set_fact:
     aap_ocp_install_eda_route: "https://{{ __aap_ocp_install_eda_route_result['resources'][0]['status']['ingress'][0]['host'] }}"
 
@@ -137,6 +142,7 @@
     - aap_ocp_install_eda is defined
     - aap_ocp_install_eda['install'] is defined
     - aap_ocp_install_eda['install'] | bool
+    - not ((__aap_ocp_install_platform_component_deployment | default('unified')) == 'individual')
   ansible.builtin.uri:
     url: "{{ aap_ocp_install_eda_route }}/api"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
@@ -155,6 +161,7 @@
     - aap_ocp_install_hub is defined
     - aap_ocp_install_hub['install'] is defined
     - aap_ocp_install_hub['install'] | bool
+    - not ((__aap_ocp_install_platform_component_deployment | default('unified')) == 'individual')
   kubernetes.core.k8s_info:
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
@@ -174,6 +181,7 @@
     - aap_ocp_install_hub is defined
     - aap_ocp_install_hub['install'] is defined
     - aap_ocp_install_hub['install'] | bool
+    - not ((__aap_ocp_install_platform_component_deployment | default('unified')) == 'individual')
   ansible.builtin.set_fact:
     aap_ocp_install_hub_route: "https://{{ __aap_ocp_install_hub_route_result['resources'][0]['status']['ingress'][0]['host'] }}"
 
@@ -182,6 +190,7 @@
     - aap_ocp_install_hub is defined
     - aap_ocp_install_hub['install'] is defined
     - aap_ocp_install_hub['install'] | bool
+    - not ((__aap_ocp_install_platform_component_deployment | default('unified')) == 'individual')
   ansible.builtin.uri:
     url: "{{ aap_ocp_install_hub_route }}/api/galaxy/pulp/api/v3/"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
@@ -195,14 +204,4 @@
   retries: 120 # Wait for 30 minutes (120*15/60)
   delay: 15
 
-- name: install-platform | Create automation platform console link
-  when:
-    - aap_ocp_install_platform['create_link'] | default(true) | bool
-  kubernetes.core.k8s:
-    host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
-    api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
-    validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
-    state: present
-    resource_definition: "{{ lookup('template', 'platform/consolelink.yaml.j2') | from_yaml | ansible.builtin.combine(aap_ocp_install_platform['consolelink_manifest_overrides'] | default({}), recursive=true) }}"
-    apply: true
 ...

--- a/roles/aap_ocp_install/tasks/main.yml
+++ b/roles/aap_ocp_install/tasks/main.yml
@@ -30,6 +30,60 @@
       tags:
         - operator
 
+    - name: Include Ansible Automation Platform controller install tasks
+      when:
+        - aap_ocp_install_controller is defined
+        - (not (__aap_ocp_install_25_install | bool))
+          or (
+            (__aap_ocp_install_25_install | bool)
+            and (aap_ocp_install_platform is defined)
+            and ((__aap_ocp_install_platform_component_deployment | default('unified')) == 'individual')
+            and (aap_ocp_install_controller['install'] | default(false) | bool)
+          )
+      ansible.builtin.include_tasks:
+        file: install-controller.yml
+        apply:
+          tags:
+            - controller
+      tags:
+        - controller
+
+    - name: Include Ansible Automation Platform hub install tasks
+      when:
+        - aap_ocp_install_hub is defined
+        - (not (__aap_ocp_install_25_install | bool))
+          or (
+            (__aap_ocp_install_25_install | bool)
+            and (aap_ocp_install_platform is defined)
+            and ((__aap_ocp_install_platform_component_deployment | default('unified')) == 'individual')
+            and (aap_ocp_install_hub['install'] | default(false) | bool)
+          )
+      ansible.builtin.include_tasks:
+        file: install-hub.yml
+        apply:
+          tags:
+            - hub
+      tags:
+        - hub
+
+    - name: Include Ansible Automation Platform EDA install tasks
+      when:
+        - aap_ocp_install_eda is defined
+        - (not (__aap_ocp_install_25_install | bool))
+          or (
+            (__aap_ocp_install_25_install | bool)
+            and (aap_ocp_install_platform is defined)
+            and ((__aap_ocp_install_platform_component_deployment | default('unified')) == 'individual')
+            and (aap_ocp_install_eda['install'] | default(false) | bool)
+          )
+      ansible.builtin.include_tasks:
+        file: install-eda.yml
+        apply:
+          tags:
+            - eda
+      tags:
+        - eda
+
     - name: Include Ansible Automation Platform platform install tasks
       when:
         - aap_ocp_install_platform is defined
@@ -42,41 +96,14 @@
       tags:
         - platform
 
-    - name: Include Ansible Automation Platform controller install tasks
-      when:
-        - aap_ocp_install_controller is defined
-        - not __aap_ocp_install_25_install | bool
+    - name: Include Ansible Automation Platform ConsoleLink tasks
       ansible.builtin.include_tasks:
-        file: install-controller.yml
-        apply:
-          tags:
-            - controller
+        file: consolelinks.yml
       tags:
         - controller
-
-    - name: Include Ansible Automation Platform hub install tasks
-      when:
-        - aap_ocp_install_hub is defined
-        - not __aap_ocp_install_25_install | bool
-      ansible.builtin.include_tasks:
-        file: install-hub.yml
-        apply:
-          tags:
-            - hub
-      tags:
         - hub
-
-    - name: Include Ansible Automation Platform EDA install tasks
-      when:
-        - aap_ocp_install_eda is defined
-        - not __aap_ocp_install_25_install | bool
-      ansible.builtin.include_tasks:
-        file: install-eda.yml
-        apply:
-          tags:
-            - eda
-      tags:
         - eda
+        - platform
 
   always:
     - name: Include OpenShift finalization tasks

--- a/roles/aap_ocp_install/tasks/pre-validate-platform-individual.yml
+++ b/roles/aap_ocp_install/tasks/pre-validate-platform-individual.yml
@@ -1,0 +1,61 @@
+---
+# Namespace alignment required by the operator when linking standalone CRs from AnsibleAutomationPlatform.
+
+- name: pre-validate-platform-individual | Resolve effective platform namespace
+  ansible.builtin.set_fact:
+    __aap_ocp_install_platform_effective_ns: "{{ aap_ocp_install_platform['namespace'] | default(aap_ocp_install_namespace) }}"
+
+- name: pre-validate-platform-individual | Ensure controller namespace matches platform namespace when installing controller (block)
+  when:
+    - aap_ocp_install_controller is defined
+    - aap_ocp_install_controller['install'] is defined
+    - aap_ocp_install_controller['install'] | bool
+  block:
+    - name: pre-validate-platform-individual | Ensure controller namespace matches platform namespace when installing controller
+      ansible.builtin.assert:
+        that:
+          - (aap_ocp_install_controller['namespace'] | default(aap_ocp_install_namespace)) == __aap_ocp_install_platform_effective_ns
+        quiet: true
+  rescue:
+    - name: pre-validate-platform-individual | Update validation errors fact - controller namespace
+      ansible.builtin.set_fact:
+        __aap_ocp_install_prevalidate_errors: >
+          {{ __aap_ocp_install_prevalidate_errors +
+          ["individual mode requires aap_ocp_install_controller namespace (or default aap_ocp_install_namespace) to match the platform namespace"] }}
+
+- name: pre-validate-platform-individual | Ensure hub namespace matches platform namespace when installing hub (block)
+  when:
+    - aap_ocp_install_hub is defined
+    - aap_ocp_install_hub['install'] is defined
+    - aap_ocp_install_hub['install'] | bool
+  block:
+    - name: pre-validate-platform-individual | Ensure hub namespace matches platform namespace when installing hub
+      ansible.builtin.assert:
+        that:
+          - (aap_ocp_install_hub['namespace'] | default(aap_ocp_install_namespace)) == __aap_ocp_install_platform_effective_ns
+        quiet: true
+  rescue:
+    - name: pre-validate-platform-individual | Update validation errors fact - hub namespace
+      ansible.builtin.set_fact:
+        __aap_ocp_install_prevalidate_errors: >
+          {{ __aap_ocp_install_prevalidate_errors +
+          ["individual mode requires aap_ocp_install_hub namespace (or default aap_ocp_install_namespace) to match the platform namespace"] }}
+
+- name: pre-validate-platform-individual | Ensure EDA namespace matches platform namespace when installing EDA (block)
+  when:
+    - aap_ocp_install_eda is defined
+    - aap_ocp_install_eda['install'] is defined
+    - aap_ocp_install_eda['install'] | bool
+  block:
+    - name: pre-validate-platform-individual | Ensure EDA namespace matches platform namespace when installing EDA
+      ansible.builtin.assert:
+        that:
+          - (aap_ocp_install_eda['namespace'] | default(aap_ocp_install_namespace)) == __aap_ocp_install_platform_effective_ns
+        quiet: true
+  rescue:
+    - name: pre-validate-platform-individual | Update validation errors fact - EDA namespace
+      ansible.builtin.set_fact:
+        __aap_ocp_install_prevalidate_errors: >
+          {{ __aap_ocp_install_prevalidate_errors +
+          ["individual mode requires aap_ocp_install_eda namespace (or default aap_ocp_install_namespace) to match the platform namespace"] }}
+...

--- a/roles/aap_ocp_install/tasks/pre-validate-platform.yml
+++ b/roles/aap_ocp_install/tasks/pre-validate-platform.yml
@@ -1,4 +1,9 @@
 ---
+- name: pre-validate-platform | Include individual-mode namespace checks
+  when: __aap_ocp_install_platform_component_deployment == 'individual'
+  ansible.builtin.include_tasks:
+    file: pre-validate-platform-individual.yml
+
 - name: pre-validate-platform | Ensure platform instance name variable is set (block)
   block:
     - name: pre-validate-platform | Ensure platform instance name variable is set
@@ -14,6 +19,7 @@
 
 - name: pre-validate-platform | Ensure controller admin username variable is set (block)
   when:
+    - aap_ocp_install_controller is defined
     - aap_ocp_install_controller['admin_user'] is defined
   block:
     - name: pre-validate-platform | Ensure controller admin username variable is set
@@ -59,6 +65,7 @@
 
 - name: pre-validate-platform | Ensure controller image pull policy is valid (block)
   when:
+    - aap_ocp_install_controller is defined
     - aap_ocp_install_controller['image_pull_policy'] is defined
   block:
     - name: pre-validate-platform | Ensure controller image pull policy is valid
@@ -74,6 +81,7 @@
 
 - name: pre-validate-platform | Ensure controller create preload data is valid (block)
   when:
+    - aap_ocp_install_controller is defined
     - aap_ocp_install_controller['create_preload_data'] is defined
   block:
     - name: pre-validate-platform | Ensure controller create preload data is valid
@@ -89,6 +97,7 @@
 
 - name: pre-validate-platform | Ensure controller garbage collect secrets is valid (block)
   when:
+    - aap_ocp_install_controller is defined
     - aap_ocp_install_controller['garbage_collect_secrets'] is defined
   block:
     - name: pre-validate-platform | Ensure controller garbage collect secrets is valid
@@ -104,6 +113,7 @@
 
 - name: pre-validate-platform | Ensure controller projects persistence is valid (block)
   when:
+    - aap_ocp_install_controller is defined
     - aap_ocp_install_controller['projects_persistence'] is defined
   block:
     - name: pre-validate-platform | Ensure controller projects persistence is valid
@@ -119,6 +129,7 @@
 
 - name: pre-validate-platform | Ensure controller replicas is valid (block)
   when:
+    - aap_ocp_install_controller is defined
     - aap_ocp_install_controller['replicas'] is defined
   block:
     - name: pre-validate-platform | Ensure controller replicas is valid
@@ -134,6 +145,7 @@
 
 - name: pre-validate-platform | Ensure controller projects storage size is valid (block)
   when:
+    - aap_ocp_install_controller is defined
     - aap_ocp_install_controller['projects_storage_size'] is defined
   block:
     - name: pre-validate-platform | Ensure controller projects storage size is valid
@@ -166,6 +178,7 @@
 
 - name: pre-validate-platform | Ensure hub file storage settings are valid (block)
   when:
+    - aap_ocp_install_hub is defined
     - aap_ocp_install_hub['storage_type'] is defined
     - aap_ocp_install_hub['storage_type'] == 'file'
   block:
@@ -183,6 +196,7 @@
 
 - name: pre-validate-platform | Ensure hub S3 storage settings are valid (block)
   when:
+    - aap_ocp_install_hub is defined
     - aap_ocp_install_hub['storage_type'] is defined
     - aap_ocp_install_hub['storage_type'] == 'S3'
   block:
@@ -199,6 +213,7 @@
 
 - name: pre-validate-platform | Ensure hub Azure storage settings are valid (block)
   when:
+    - aap_ocp_install_hub is defined
     - aap_ocp_install_hub['storage_type'] is defined
     - aap_ocp_install_hub['storage_type'] == 'azure'
   block:

--- a/roles/aap_ocp_install/tasks/pre-validate.yml
+++ b/roles/aap_ocp_install/tasks/pre-validate.yml
@@ -119,6 +119,30 @@
   ansible.builtin.set_fact:
     __aap_ocp_install_25_install: false
 
+- name: pre-validate | Set platform component deployment mode when using AAP 2.5+ platform install
+  when:
+    - aap_ocp_install_platform is defined
+    - __aap_ocp_install_25_install | bool
+  ansible.builtin.set_fact:
+    __aap_ocp_install_platform_component_deployment: "{{ aap_ocp_install_platform['component_deployment'] | default('unified') }}"
+
+- name: pre-validate | Ensure platform component_deployment is unified or individual
+  when:
+    - aap_ocp_install_platform is defined
+    - __aap_ocp_install_25_install | bool
+  block:
+    - name: pre-validate | Assert component_deployment value
+      ansible.builtin.assert:
+        that:
+          - __aap_ocp_install_platform_component_deployment in ['unified', 'individual']
+        quiet: true
+  rescue:
+    - name: pre-validate | Update validation errors fact - component_deployment
+      ansible.builtin.set_fact:
+        __aap_ocp_install_prevalidate_errors: >
+          {{ __aap_ocp_install_prevalidate_errors +
+          ["aap_ocp_install_platform['component_deployment'] must be 'unified' or 'individual'"] }}
+
 - name: pre-validate | Ensure platform variables are set
   when:
     - (( 'platform' in ansible_run_tags ) or ( 'all' in ansible_run_tags and aap_ocp_install_platform is defined ))
@@ -129,21 +153,39 @@
 - name: pre-validate | Ensure controller variables are set
   when:
     - (( 'controller' in ansible_run_tags ) or ( 'all' in ansible_run_tags and aap_ocp_install_controller is defined ))
-    - not (__aap_ocp_install_25_install | bool)
+    - (not (__aap_ocp_install_25_install | bool))
+      or (
+        (__aap_ocp_install_25_install | bool)
+        and (aap_ocp_install_platform is defined)
+        and ((__aap_ocp_install_platform_component_deployment | default('unified')) == 'individual')
+        and (aap_ocp_install_controller['install'] | default(false) | bool)
+      )
   ansible.builtin.include_tasks:
     file: pre-validate-controller.yml
 
 - name: pre-validate | Ensure hub variables are set
   when:
     - (( 'hub' in ansible_run_tags ) or ( 'all' in ansible_run_tags and aap_ocp_install_hub is defined ))
-    - not (__aap_ocp_install_25_install | bool)
+    - (not (__aap_ocp_install_25_install | bool))
+      or (
+        (__aap_ocp_install_25_install | bool)
+        and (aap_ocp_install_platform is defined)
+        and ((__aap_ocp_install_platform_component_deployment | default('unified')) == 'individual')
+        and (aap_ocp_install_hub['install'] | default(false) | bool)
+      )
   ansible.builtin.include_tasks:
     file: pre-validate-hub.yml
 
 - name: pre-validate | Ensure eda variables are set
   when:
     - (( 'eda' in ansible_run_tags ) or ( 'all' in ansible_run_tags and aap_ocp_install_eda is defined ))
-    - not (__aap_ocp_install_25_install | bool)
+    - (not (__aap_ocp_install_25_install | bool))
+      or (
+        (__aap_ocp_install_25_install | bool)
+        and (aap_ocp_install_platform is defined)
+        and ((__aap_ocp_install_platform_component_deployment | default('unified')) == 'individual')
+        and (aap_ocp_install_eda['install'] | default(false) | bool)
+      )
   ansible.builtin.include_tasks:
     file: pre-validate-eda.yml
 

--- a/roles/aap_ocp_install/templates/operator/subscription.yaml.j2
+++ b/roles/aap_ocp_install/templates/operator/subscription.yaml.j2
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ aap_ocp_install_namespace }}
 spec:
   channel: {{ aap_ocp_install_operator['channel'] }}
-  installPlanApproval: {{ aap_ocp_install_operator['approval'] | default('Automatic') }}
+  installPlanApproval: {{ 'Manual' if ((aap_ocp_install_operator['approval'] | default('automatic')) | lower) == 'manual' else 'Automatic' }}
   startingCSV: {{ aap_ocp_install_operator['starting_csv'] | default(omit) }}
   name: ansible-automation-platform-operator
   source: redhat-operators

--- a/roles/aap_ocp_install/templates/platform/instance.yaml.j2
+++ b/roles/aap_ocp_install/templates/platform/instance.yaml.j2
@@ -9,6 +9,7 @@ spec:
   image_pull_policy: IfNotPresent
 
   # Components
+{% if (__aap_ocp_install_platform_component_deployment | default('unified')) == 'unified' %}
 {% if aap_ocp_install_controller is defined and aap_ocp_install_controller['install'] is defined and aap_ocp_install_controller['install'] %}
   controller:
     disabled: false
@@ -51,6 +52,34 @@ spec:
 {% else %}
   hub:
     disabled: true
+{% endif %}
+{% else %}
+{% if aap_ocp_install_controller is defined and aap_ocp_install_controller['install'] is defined and aap_ocp_install_controller['install'] %}
+  controller:
+    name: {{ aap_ocp_install_controller['instance_name'] }}
+    disabled: false
+{% else %}
+  controller:
+    disabled: true
+{% endif %}
+
+{% if aap_ocp_install_eda is defined and aap_ocp_install_eda['install'] is defined and aap_ocp_install_eda['install'] %}
+  eda:
+    name: {{ aap_ocp_install_eda['instance_name'] }}
+    disabled: false
+{% else %}
+  eda:
+    disabled: true
+{% endif %}
+
+{% if aap_ocp_install_hub is defined and aap_ocp_install_hub['install'] is defined and aap_ocp_install_hub['install'] %}
+  hub:
+    name: {{ aap_ocp_install_hub['instance_name'] }}
+    disabled: false
+{% else %}
+  hub:
+    disabled: true
+{% endif %}
 {% endif %}
 
   lightspeed:


### PR DESCRIPTION
## Summary

Adds `aap_ocp_install_platform.component_deployment` so Ansible Automation Platform 2.5+ on OpenShift can be installed either with components embedded in a single `AnsibleAutomationPlatform` custom resource (unified) or with standalone component CRs created first and linked by name (individual).

## What this changeset does

- Introduces the platform `component_deployment` choice and wires it through validation, install flow, and the platform instance template.
- In individual mode, skips merging component manifest overrides into the Platform CR so the spec does not contain invalid duplicates.
- Adds individual-mode platform pre-validation (`pre-validate-platform-individual.yml`) and extends shared platform pre-validation.
- Centralizes ConsoleLink handling in `consolelinks.yml` and removes duplicated blocks from controller, hub, and EDA install task files.
- Updates operator subscription templating and small install-operator / install-platform adjustments to match the flow.
- Refreshes the role README (including variable tables aligned for markdownlint MD060) to document tags, overrides, and the new behavior.


Made with [Cursor](https://cursor.com)