### PR TITLE
Make no_log configurable with global variable

### DIFF
--- a/changelogs/fragments/parameterized_no_log.yml
+++ b/changelogs/fragments/parameterized_no_log.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Introduced global variable aap_no_log to control logging of sensitive information across all roles, defaulting to true for security while allowing users to enable detailed logging for troubleshooting by setting it to false.

--- a/roles/aap_certs/tasks/autohub.yml
+++ b/roles/aap_certs/tasks/autohub.yml
@@ -2,7 +2,7 @@
 # according to https://access.redhat.com/solutions/5731261
 
 - name: autohub | Get certificate file content
-  no_log: true
+  no_log: "{{ aap_no_log | default(true) }}"
   when:
     - aap_certs_autohub_ssl_cert is defined
     - aap_certs_autohub_ssl_key is defined
@@ -11,7 +11,7 @@
     aap_certs_autohub_ssl_key_content: "{{ lookup('ansible.builtin.file', aap_certs_autohub_ssl_key) }}"
 
 - name: autohub | Update certificate file
-  no_log: true
+  no_log: "{{ aap_no_log | default(true) }}"
   become: true
   ansible.builtin.template:
     src: cert_content.j2
@@ -25,7 +25,7 @@
     file_content: "{{ aap_certs_autohub_ssl_cert_content }}"
 
 - name: autohub | Update certificate key file
-  no_log: true
+  no_log: "{{ aap_no_log | default(true) }}"
   become: true
   ansible.builtin.template:
     src: cert_content.j2

--- a/roles/aap_certs/tasks/controller.yml
+++ b/roles/aap_certs/tasks/controller.yml
@@ -2,7 +2,7 @@
 # according to https://access.redhat.com/solutions/3109871
 
 - name: controller | Get certificate file content
-  no_log: true
+  no_log: "{{ aap_no_log | default(true) }}"
   when:
     - aap_certs_controller_ssl_cert is defined
     - aap_certs_controller_ssl_key is defined
@@ -11,7 +11,7 @@
     aap_certs_controller_ssl_key_content: "{{ lookup('ansible.builtin.file', aap_certs_controller_ssl_key) }}"
 
 - name: controller | Update certificate file
-  no_log: true
+  no_log: "{{ aap_no_log | default(true) }}"
   become: true
   ansible.builtin.template:
     src: cert_content.j2
@@ -25,7 +25,7 @@
     file_content: "{{ aap_certs_controller_ssl_cert_content }}"
 
 - name: controller | Update certificate key file
-  no_log: true
+  no_log: "{{ aap_no_log | default(true) }}"
   become: true
   ansible.builtin.template:
     src: cert_content.j2

--- a/roles/aap_certs/tasks/edacontroller.yml
+++ b/roles/aap_certs/tasks/edacontroller.yml
@@ -1,6 +1,6 @@
 ---
 - name: edacontroller | Get certificate file content
-  no_log: true
+  no_log: "{{ aap_no_log | default(true) }}"
   when:
     - aap_certs_eda_ssl_cert is defined
     - aap_certs_eda_ssl_key is defined
@@ -9,7 +9,7 @@
     aap_certs_eda_ssl_key_content: "{{ lookup('ansible.builtin.file', aap_certs_eda_ssl_key) }}"
 
 - name: edacontroller | Update certificate file
-  no_log: true
+  no_log: "{{ aap_no_log | default(true) }}"
   become: true
   ansible.builtin.template:
     src: cert_content.j2
@@ -23,7 +23,7 @@
     file_content: "{{ aap_certs_eda_ssl_cert_content }}"
 
 - name: edacontroller | Update certificate key file
-  no_log: true
+  no_log: "{{ aap_no_log | default(true) }}"
   become: true
   ansible.builtin.template:
     src: cert_content.j2

--- a/roles/aap_ocp_install/tasks/validate-connection.yml
+++ b/roles/aap_ocp_install/tasks/validate-connection.yml
@@ -1,6 +1,6 @@
 ---
 - name: validate-connection | Validate OpenShift API key
-  no_log: true
+  no_log: "{{ aap_no_log | default(true) }}"
   ansible.builtin.uri:
     url: "{{  __aap_ocp_install_auth_results['openshift_auth']['host'] }}/version"
     method: GET

--- a/roles/aap_setup_download/tasks/main.yml
+++ b/roles/aap_setup_download/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 # tasks file for aap_setup_download
 - name: Login to Red Hat APIs
-  no_log: true
+  no_log: "{{ aap_no_log | default(true) }}"
   ansible.builtin.uri:
     url: "{{ aap_setup_down_token_url }}"
     method: POST
@@ -13,7 +13,7 @@
   register: __aap_setup_down_login
 
 - name: Collecting the available installers
-  no_log: true
+  no_log: "{{ aap_no_log | default(true) }}"
   ansible.builtin.uri:
     url: "{{ aap_setup_down_images_url }}"
     method: GET
@@ -67,7 +67,7 @@
   when: not is_aap_setup_down_latest
 
 - name: Downloading the installer of type {{ aap_setup_down_type }}
-  no_log: true
+  no_log: "{{ aap_no_log | default(true) }}"
   ansible.builtin.get_url:
     url: "{{ __aap_image_to_download.downloadHref }}"
     dest: "{{ aap_setup_down_dest_dir }}/{{ __aap_image_to_download.filename }}"

--- a/roles/aap_setup_install/tasks/containerized.yml
+++ b/roles/aap_setup_install/tasks/containerized.yml
@@ -1,6 +1,6 @@
 ---
 - name: containerized | Check Automation Controller Running
-  no_log: true
+  no_log: "{{ aap_no_log | default(true) }}"
   ansible.builtin.uri:
     url: https://{{ controller_hostname }}:{{ __aap_setup_inst_controller_port }}/api/
     method: GET
@@ -16,7 +16,7 @@
     - not aap_setup_inst_force | bool
 
 - name: containerized | Check Automation Hub Running
-  no_log: true
+  no_log: "{{ aap_no_log | default(true) }}"
   ansible.builtin.uri:
     url: https://{{ ah_hostname }}:{{ __aap_setup_inst_hub_port }}/api/galaxy/
     method: GET
@@ -32,7 +32,7 @@
     - not aap_setup_inst_force | bool
 
 - name: containerized | Check EDA Controller Running
-  no_log: true
+  no_log: "{{ aap_no_log | default(true) }}"
   ansible.builtin.uri:
     url: https://{{ eda_hostname }}:{{ __aap_setup_inst_eda_port }}/
     method: GET

--- a/roles/aap_setup_install/tasks/setup.yml
+++ b/roles/aap_setup_install/tasks/setup.yml
@@ -1,6 +1,6 @@
 ---
 - name: setup | Check Automation Controller Running
-  no_log: true
+  no_log: "{{ aap_no_log | default(true) }}"
   ansible.builtin.uri:
     url: https://{{ controller_hostname }}/
     method: GET
@@ -17,7 +17,7 @@
     - not aap_setup_inst_force | bool
 
 - name: setup | Check Automation Hub Running
-  no_log: true
+  no_log: "{{ aap_no_log | default(true) }}"
   ansible.builtin.uri:
     url: https://{{ ah_hostname }}/api/galaxy/
     method: GET
@@ -34,7 +34,7 @@
     - not aap_setup_inst_force | bool
 
 - name: setup | Check EDA Controller Running
-  no_log: true
+  no_log: "{{ aap_no_log | default(true) }}"
   ansible.builtin.uri:
     url: https://{{ eda_hostname }}/
     method: GET
@@ -51,7 +51,7 @@
     - not aap_setup_inst_force | bool
 
 - name: setup | Check Gateway API Status
-  no_log: true
+  no_log: "{{ aap_no_log | default(true) }}"
   ansible.builtin.uri:
     url: https://{{ gateway_hostname }}/api/gateway/v1/status/?service_keys=true
     method: GET


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

### Summary
This PR replaces all hardcoded `no_log: true` statements across AAP utilities roles with a configurable `aap_no_log` variable that defaults to `true`.

### Motivation
While hiding sensitive information by default is important for security, the current hardcoded approach makes debugging difficult. When users encounter authentication failures, API errors, or certificate issues, they need to manually edit multiple task files to enable logging. This PR makes troubleshooting easier while maintaining secure defaults.

### Changes
- **20 tasks updated** across 4 roles
- Replaced `no_log: true` with `no_log: "{{ aap_no_log | default(true) }}"`
- No changes to default behavior - still secure by default

#### Modified Roles
- `aap_setup_download` (3 tasks in `tasks/main.yml`)
- `aap_certs` (9 tasks across `tasks/controller.yml`, `tasks/autohub.yml`, `tasks/edacontroller.yml`)
- `aap_setup_install` (7 tasks in `tasks/setup.yml` and `tasks/containerized.yml`)
- `aap_ocp_install` (1 task in `tasks/validate-connection.yml`)

### Usage
Users can now enable logging globally when needed:

```yaml
---
- hosts: localhost
  vars:
    aap_no_log: false  # Enable logging for debugging
  roles:
    - aap_setup_download
    - aap_certs
```
### Backwards Compatibility
✅ **Fully backwards compatible** - defaults to `true` if not specified, maintaining current secure behavior.

# How should this be tested?

### Testing Recommendations
- Verify roles work with `aap_no_log: true` (default)
- Verify roles work with `aap_no_log: false` (debug mode)
- Verify roles work without the variable defined (should default to `true`)

# Is there a relevant Issue open for this?

Provide a link to any open issues that describe the problem you are solving.
resolves #356 

# Other Relevant info, PRs, etc

### Security Note
The default value remains `true` to protect sensitive data (passwords, tokens, API keys, certificates). Users must explicitly set `aap_no_log: false` to enable logging, and should only do so in secure debugging environments.
